### PR TITLE
Fix frontend dev API config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
     build:
       context: .
       dockerfile: ./frontend/Dockerfile
+      args:
+        VITE_API_BASE: http://localhost:5001
     container_name: ajt_frontend
     ports:
       - "3000:80"


### PR DESCRIPTION
## Summary
- enable dev frontend to reach the backend
- allow backend to accept both 5173 and 3000

## Testing
- `pytest`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68776637bcc0832799e46b64a05e0819