### PR TITLE
Display server error messages in notifications

### DIFF
--- a/frontend/src/components/FormattingPage.tsx
+++ b/frontend/src/components/FormattingPage.tsx
@@ -319,12 +319,12 @@ function FormattingPage({ onBack }: FormattingPageProps) {
 
     } catch (error) {
       console.error('Error formatting file:', error);
-      setError(
+      const message =
         error instanceof Error
           ? error.message
-          : 'Impossible de formater le fichier. Veuillez vérifier le fichier et réessayer.'
-      );
-      notify('Erreur lors du formatage du fichier', 'error');
+          : 'Impossible de formater le fichier. Veuillez vérifier le fichier et réessayer.';
+      setError(message);
+      notify(message, 'error');
       setFormattedFile(null);
       setHtmlFile(null);
     } finally {

--- a/frontend/src/components/ProcessingPage.tsx
+++ b/frontend/src/components/ProcessingPage.tsx
@@ -220,12 +220,12 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
 
     } catch (err) {
       console.error('Error processing files:', err);
-      setError(
+      const message =
         err instanceof Error
           ? err.message
-          : 'Le traitement des fichiers a échoué. Veuillez vérifier les fichiers et réessayer.'
-      );
-      notify('Erreur lors du traitement des fichiers', 'error');
+          : 'Le traitement des fichiers a échoué. Veuillez vérifier les fichiers et réessayer.';
+      setError(message);
+      notify(message, 'error');
       setProcessedFile(null);
     } finally {
       setIsProcessing(false);


### PR DESCRIPTION
## Summary
- show backend error text in FormattingPage and ProcessingPage notifications

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails to run due to environment network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6877ff324ee08327b26e35ce9d743d9b