### PR TITLE
Use email for authentication

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -13,12 +13,12 @@ bp = Blueprint("auth", __name__)
 @bp.route("/login", methods=["POST"])
 def login():
     data = request.get_json(silent=True) or {}
-    username = data.get("username")
+    email = data.get("email")
     password = data.get("password")
-    if not username or not password:
-        return jsonify({"error": "Nom d'utilisateur et mot de passe requis"}), 400
+    if not email or not password:
+        return jsonify({"error": "Email et mot de passe requis"}), 400
 
-    user = User.query.filter_by(username=username).first()
+    user = User.query.filter_by(email=email).first()
     if not user or not user.check_password(password):
         return jsonify({"error": "Identifiants invalides"}), 401
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,11 +49,11 @@ async function fetchWithAuth(url: string, options: RequestInit = {}) {
   return res;
 }
 
-export async function login(username: string, password: string) {
+export async function login(email: string, password: string) {
   const res = await fetch(`${API_BASE}/login`, {
     method: 'POST',
     headers: authHeaders({ 'Content-Type': 'application/json' }),
-    body: JSON.stringify({ username, password })
+    body: JSON.stringify({ email, password })
   });
   if (!res.ok) {
     console.log("🔧 API base URL =", import.meta.env.VITE_API_BASE);

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -7,14 +7,14 @@ interface Props {
 }
 
 export default function LoginPage({ onLogin }: Props) {
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const notify = useNotification();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const data = await login(username, password);
+      const data = await login(email, password);
       onLogin(data.role, data.token, data.refresh_token);
     } catch (err: any) {
       notify(err.message || 'Erreur de connexion', 'error');
@@ -26,10 +26,10 @@ export default function LoginPage({ onLogin }: Props) {
       <form onSubmit={handleSubmit} className="bg-zinc-800 p-6 rounded space-y-4 w-80">
         <h1 className="text-xl font-bold text-center">Connexion</h1>
         <input
-          type="text"
-          placeholder="Utilisateur"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
           className="w-full px-3 py-2 bg-zinc-700 rounded"
         />
         <input


### PR DESCRIPTION
## Summary
- Accept email for backend login, replacing username
- Update frontend login API and page to send email for authentication

## Testing
- `npm run lint` (fails: Cannot find package 'typescript-eslint')
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3857c40e48327b7b28fdd24665fe9