### PR TITLE
Add product deletion controls to reference view

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -167,6 +167,18 @@ export async function deleteProduct(id: number) {
   return res.json();
 }
 
+export async function bulkDeleteProducts(ids: number[]) {
+  const res = await fetchWithAuth(`${API_BASE}/products/bulk_delete`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids })
+  });
+  if (!res.ok) {
+    throw new Error(await extractErrorMessage(res));
+  }
+  return res.json();
+}
+
 
 export async function fetchLastImport(id: number): Promise<{ import_date: string | null } | {}> {
   const res = await fetchWithAuth(`${API_BASE}/last_import/${id}`);


### PR DESCRIPTION
## Summary
- add a bulk product deletion route to the products API
- expose the new deletion helper on the frontend API client
- add row-level and bulk deletion controls with confirmation prompts on the product reference table

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d2fe3bfe548327896e2ac743cc21a0