### PR TITLE
Filter product calculations to the current week

### DIFF
--- a/backend/routes/products.py
+++ b/backend/routes/products.py
@@ -30,9 +30,18 @@ def list_product_calculations():
       200:
         description: Calculated prices for all products
     """
+    now = datetime.utcnow()
+    start_of_week = now - timedelta(days=now.weekday())
+    start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_of_week = start_of_week + timedelta(days=7)
+
     calculations = (
         ProductCalculation.query.join(Product)
         .join(Brand)
+        .filter(
+            ProductCalculation.date >= start_of_week,
+            ProductCalculation.date < end_of_week,
+        )
         .order_by(Brand.brand, Product.model)
         .all()
     )


### PR DESCRIPTION
## Summary
- limit the product calculation list to records dated within the current week so the TCP/marge view shows the relevant supplier entry

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ee8bfbeb148327b183b23acb4f48f9