### PR TITLE
Hide statistics tab from navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,6 +85,7 @@ function App() {
                 <button
                   onClick={() => setCurrentPage('statistics')}
                   className={`btn px-6 py-3 ${currentPage === 'statistics' ? 'btn-primary' : 'btn-secondary'}`}
+                  style={{ display: 'none' }}
                 >
                   <BarChart3 className="w-5 h-5" />
                   <span>Statistiques</span>


### PR DESCRIPTION
## Summary
- hide the Statistiques navigation button while keeping the underlying page code intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee8c092010832788a4af640595f503