### PR TITLE
feat: add search home page and grouped settings menu

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,23 @@
-import { BarChart3, LibraryBig, Settings, Upload } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { ChevronDown, LibraryBig, LogOut, Search, Settings, Upload } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import { fetchApitest, setAuthToken, setRefreshToken } from './api';
 import AdminPage from './components/AdminPage';
 import DataImportPage from './components/DataImportPage';
 import LoginPage from './components/LoginPage';
 import ProductsPage from './components/ProductsPage';
+import SearchPage from './components/SearchPage';
 import StatisticsPage from './components/StatisticsPage';
 
 function App() {
   const storedRole = localStorage.getItem('role');
-  const [currentPage, setCurrentPage] = useState<'products' | 'dataImport' | 'statistics' | 'admin'>('products');
+  const [currentPage, setCurrentPage] = useState<'search' | 'products' | 'dataImport' | 'statistics' | 'admin'>('search');
   const [apiTestMessage, setApiTestMessage] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
   const [role, setRole] = useState<string>(storedRole || '');
+  const [showProductsMenu, setShowProductsMenu] = useState(false);
+  const [showSettingsMenu, setShowSettingsMenu] = useState(false);
+  const productsMenuRef = useRef<HTMLDivElement | null>(null);
+  const settingsMenuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (token) {
@@ -26,7 +31,7 @@ function App() {
     localStorage.setItem('role', userRole);
     setAuthToken(newToken);
     setRefreshToken(newRefresh);
-    setCurrentPage('products');
+    setCurrentPage('search');
   };
 
   const handleLogout = () => {
@@ -35,7 +40,8 @@ function App() {
     setAuthToken(null);
     setRefreshToken(null);
     localStorage.removeItem('role');
-    setCurrentPage('products');
+    setCurrentPage('search');
+    setShowSettingsMenu(false);
   };
 
   useEffect(() => {
@@ -54,10 +60,32 @@ function App() {
     }
   };
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        productsMenuRef.current &&
+        !productsMenuRef.current.contains(event.target as Node)
+      ) {
+        setShowProductsMenu(false);
+      }
+      if (
+        settingsMenuRef.current &&
+        !settingsMenuRef.current.contains(event.target as Node)
+      ) {
+        setShowSettingsMenu(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
 
   if (!token) {
     return <LoginPage onLogin={handleLogin} />;
   }
+
+  const isProductsActive = currentPage === 'products' || currentPage === 'dataImport';
 
   return (
     <div className="min-h-screen text-white flex flex-col">
@@ -66,45 +94,109 @@ function App() {
         <div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
           <div className="flex flex-wrap items-center justify-between gap-2">
 
-            <button
-              onClick={() => setCurrentPage('products')}
-              className={`btn px-6 py-3 ${currentPage === 'products' ? 'btn-primary' : 'btn-secondary'}`}
-            >
-              <LibraryBig className="w-5 h-5" />
-              <span>Produits</span>
-            </button>
-            {role !== 'client' && (
-              <>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                onClick={() => {
+                  setCurrentPage('search');
+                  setShowProductsMenu(false);
+                  setShowSettingsMenu(false);
+                }}
+                className={`btn px-6 py-3 ${currentPage === 'search' ? 'btn-primary' : 'btn-secondary'}`}
+              >
+                <Search className="w-5 h-5" />
+                <span>Moteur de recherche</span>
+              </button>
+
+              <div className="relative" ref={productsMenuRef}>
                 <button
-                  onClick={() => setCurrentPage('dataImport')}
-                  className={`btn px-6 py-3 ${currentPage === 'dataImport' ? 'btn-primary' : 'btn-secondary'}`}
+                  onClick={() => {
+                    setCurrentPage('products');
+                    setShowSettingsMenu(false);
+                    if (role !== 'client') {
+                      setShowProductsMenu((prev) => !prev);
+                    }
+                  }}
+                  className={`btn px-6 py-3 ${isProductsActive ? 'btn-primary' : 'btn-secondary'}`}
                 >
-                  <Upload className="w-5 h-5" />
-                  <span>Import de données</span>
+                  <LibraryBig className="w-5 h-5" />
+                  <span>Produits</span>
+                  {role !== 'client' && <ChevronDown className="w-4 h-4 ml-2" />}
                 </button>
-                <button
-                  onClick={() => setCurrentPage('statistics')}
-                  className={`btn px-6 py-3 ${currentPage === 'statistics' ? 'btn-primary' : 'btn-secondary'}`}
-                  style={{ display: 'none' }}
-                >
-                  <BarChart3 className="w-5 h-5" />
-                  <span>Statistiques</span>
-                </button>
-                <button
-                  onClick={() => setCurrentPage('admin')}
-                  className={`btn px-6 py-3 ${currentPage === 'admin' ? 'btn-primary' : 'btn-secondary'}`}
-                >
-                  <Settings className="w-5 h-5" />
-                  <span>Admin</span>
-                </button>
-              </>
-            )}
-            <button onClick={handleLogout} className="btn btn-secondary">Déconnexion</button>
+                {role !== 'client' && showProductsMenu && (
+                  <div className="absolute mt-2 w-48 rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl">
+                    <button
+                      onClick={() => {
+                        setCurrentPage('products');
+                        setShowProductsMenu(false);
+                      }}
+                      className={`flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-zinc-800 ${
+                        currentPage === 'products' ? 'text-[#B8860B]' : 'text-white'
+                      }`}
+                    >
+                      <LibraryBig className="w-4 h-4" />
+                      <span>Produits</span>
+                    </button>
+                    <button
+                      onClick={() => {
+                        setCurrentPage('dataImport');
+                        setShowProductsMenu(false);
+                      }}
+                      className={`flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-zinc-800 ${
+                        currentPage === 'dataImport' ? 'text-[#B8860B]' : 'text-white'
+                      }`}
+                    >
+                      <Upload className="w-4 h-4" />
+                      <span>Import</span>
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="relative" ref={settingsMenuRef}>
+              <button
+                onClick={() => {
+                  setShowProductsMenu(false);
+                  setShowSettingsMenu((prev) => !prev);
+                }}
+                className={`btn px-6 py-3 ${currentPage === 'admin' ? 'btn-primary' : 'btn-secondary'}`}
+              >
+                <Settings className="w-5 h-5" />
+                <span>Paramètres</span>
+                <ChevronDown className="w-4 h-4 ml-2" />
+              </button>
+              {showSettingsMenu && (
+                <div className="absolute right-0 mt-2 w-48 rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl">
+                  {role !== 'client' && (
+                    <button
+                      onClick={() => {
+                        setCurrentPage('admin');
+                        setShowSettingsMenu(false);
+                      }}
+                      className={`flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-zinc-800 ${
+                        currentPage === 'admin' ? 'text-[#B8860B]' : 'text-white'
+                      }`}
+                    >
+                      <Settings className="w-4 h-4" />
+                      <span>Admin</span>
+                    </button>
+                  )}
+                  <button
+                    onClick={handleLogout}
+                    className="flex w-full items-center gap-2 px-4 py-3 text-left text-white hover:bg-zinc-800"
+                  >
+                    <LogOut className="w-4 h-4" />
+                    <span>Déconnexion</span>
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
 
       {/* Page Content */}
+      {currentPage === 'search' && <SearchPage />}
       {role !== 'client' && currentPage === 'dataImport' && <DataImportPage />}
       {role !== 'client' && currentPage === 'statistics' && <StatisticsPage />}
       {role !== 'client' && currentPage === 'admin' && (

--- a/frontend/src/components/SearchPage.tsx
+++ b/frontend/src/components/SearchPage.tsx
@@ -1,0 +1,176 @@
+import { Loader2, PackageSearch } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { fetchProductPriceSummary } from '../api';
+import SearchControls from './SearchControls';
+
+interface SearchProduct {
+  id: string;
+  name: string;
+  description: string | null;
+  brand: string | null;
+  price: number;
+}
+
+function normalisePrice(value: unknown): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) {
+    return Math.round(value * 100) / 100;
+  }
+  return 0;
+}
+
+function SearchPage() {
+  const [products, setProducts] = useState<SearchProduct[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [minPrice, setMinPrice] = useState(0);
+  const [maxPrice, setMaxPrice] = useState(0);
+  const [priceRange, setPriceRange] = useState({ min: 0, max: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchProductPriceSummary()
+      .then((res) => {
+        const items = (res as any[]).map((item, index) => {
+          const price = normalisePrice(item.recommended_price ?? item.average_price ?? item.marge ?? 0);
+          const name = item.model ?? item.description ?? 'Produit';
+          return {
+            id: String(item.id ?? name ?? index),
+            name,
+            description: item.description ?? null,
+            brand: item.brand ?? null,
+            price,
+          } as SearchProduct;
+        });
+
+        const validPrices = items
+          .map((product) => product.price)
+          .filter((value) => typeof value === 'number' && !Number.isNaN(value));
+
+        let min = validPrices.length ? Math.floor(Math.min(...validPrices)) : 0;
+        let max = validPrices.length ? Math.ceil(Math.max(...validPrices)) : 0;
+
+        if (min === max) {
+          max = min + 1;
+        }
+
+        setPriceRange({ min, max });
+        setMinPrice(min);
+        setMaxPrice(max);
+        setProducts(items);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error('Unable to fetch product summary', err);
+        setProducts([]);
+        setPriceRange({ min: 0, max: 1 });
+        setMinPrice(0);
+        setMaxPrice(1);
+        setError("Impossible de récupérer les produits. Veuillez réessayer.");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const displayedProducts = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+
+    return products
+      .filter((product) => {
+        const matchesTerm =
+          term.length === 0 ||
+          [product.name, product.description, product.brand]
+            .filter((value): value is string => typeof value === 'string')
+            .some((value) => value.toLowerCase().includes(term));
+        const matchesPrice = product.price >= minPrice && product.price <= maxPrice;
+        return matchesTerm && matchesPrice;
+      })
+      .sort((a, b) => a.price - b.price);
+  }, [products, searchTerm, minPrice, maxPrice]);
+
+  const handlePriceRangeChange = (min: number, max: number) => {
+    setMinPrice(Math.max(priceRange.min, Math.min(min, max - 1)));
+    setMaxPrice(Math.min(priceRange.max, Math.max(max, min + 1)));
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto w-full flex-1 px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-semibold text-white mb-2 flex items-center gap-3">
+          <PackageSearch className="w-8 h-8 text-[#B8860B]" />
+          Moteur de recherche produits
+        </h1>
+        <p className="text-zinc-400 max-w-2xl">
+          Explorez l&apos;ensemble du catalogue, affinez vos recherches par prix ou mots-clés et accédez rapidement aux produits pertinents.
+        </p>
+      </div>
+
+      <div className="card p-6 mb-10">
+        <SearchControls
+          searchTerm={searchTerm}
+          onSearchChange={setSearchTerm}
+          minPrice={minPrice}
+          maxPrice={maxPrice}
+          onPriceRangeChange={handlePriceRangeChange}
+          allProducts={products.map((product) => ({
+            name: product.name,
+            price: product.price,
+            brand: product.brand ?? 'Inconnu',
+          }))}
+          priceRange={priceRange}
+        />
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20 text-zinc-400">
+          <Loader2 className="w-6 h-6 animate-spin mr-3" />
+          Chargement des produits...
+        </div>
+      ) : error ? (
+        <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-6 py-4 text-red-200">
+          {error}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-white">Résultats ({displayedProducts.length})</h2>
+            <span className="text-sm text-zinc-400">
+              Gamme sélectionnée : {minPrice}€ - {maxPrice}€
+            </span>
+          </div>
+
+          {displayedProducts.length === 0 ? (
+            <div className="rounded-xl border border-zinc-700 bg-zinc-900/60 px-6 py-12 text-center text-zinc-400">
+              Aucun produit ne correspond à votre recherche pour le moment.
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {displayedProducts.map((product) => (
+                <div
+                  key={product.id}
+                  className="rounded-xl border border-zinc-700/60 bg-zinc-900/60 p-5 transition-colors hover:border-[#B8860B]/60"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-lg font-semibold text-white line-clamp-2">{product.name}</h3>
+                      {product.brand && (
+                        <p className="mt-1 text-sm uppercase tracking-wide text-[#B8860B]">{product.brand}</p>
+                      )}
+                    </div>
+                    <div className="rounded-lg bg-[#B8860B]/10 px-3 py-2 text-[#B8860B] font-semibold">
+                      {product.price.toFixed(2)}€
+                    </div>
+                  </div>
+                  {product.description && (
+                    <p className="mt-4 text-sm text-zinc-400 line-clamp-3">{product.description}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SearchPage;


### PR DESCRIPTION
## Summary
- introduce a dedicated "Moteur de recherche" landing page with catalog filtering controls
- reorganize the navigation bar with dropdowns for Produits/Import and Paramètres (Admin & Déconnexion)

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900ec1ebfe48327a0c4f15e58510114