### PR TITLE
fix(deploy): pass .env to backend container in prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: ajt_backend_prod
+    env_file:
+      - .env
     environment:
       FLASK_ENV: production
       FLASK_DEBUG: 0


### PR DESCRIPTION
## Summary

- Add `env_file: .env` to backend service in `docker-compose.prod.yml`
- This makes `ODOO_ENCRYPTION_KEY` (injected by deploy-ci.sh) available inside the Docker container
- Fixes `RuntimeError: ODOO_ENCRYPTION_KEY is not set` during Alembic migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)