### PR TITLE
fix(tests): remove dead onAdd code and fix 3 failing tests

### DIFF
--- a/frontend/src/components/ProductReference.tsx
+++ b/frontend/src/components/ProductReference.tsx
@@ -181,45 +181,6 @@ function ProductReference() {
     }));
   };
 
-  const handleAdd = () => {
-    const id = Date.now() * -1;
-    setProducts((prev) => [
-      ...prev,
-      {
-        id,
-        ean: '',
-        model: '',
-        description: '',
-        brand_id: null,
-        brand: null,
-        memory_id: null,
-        memory: null,
-        color_id: null,
-        color: null,
-        type_id: null,
-        type: null,
-        ram_id: null,
-        ram: null,
-        norme_id: null,
-        norme: null,
-      },
-    ]);
-    setEdited((prev) => ({
-      ...prev,
-      [id]: {
-        ean: '',
-        model: '',
-        description: '',
-        brand_id: null,
-        memory_id: null,
-        color_id: null,
-        type_id: null,
-        ram_id: null,
-        norme_id: null,
-      },
-    }));
-  };
-
   const removeEditedEntries = (ids: number[]) => {
     if (!ids.length) return;
     setEdited((prev) => {
@@ -340,7 +301,6 @@ function ProductReference() {
         showColumnMenu={showColumnMenu}
         onToggleColumnMenu={() => setShowColumnMenu((s) => !s)}
         onToggleColumn={toggleColumn}
-        onAdd={handleAdd}
         onSave={saveAll}
         onBulkDelete={handleBulkDelete}
         selectedCount={selectedCount}

--- a/frontend/src/components/ProductReferenceForm.tsx
+++ b/frontend/src/components/ProductReferenceForm.tsx
@@ -6,7 +6,6 @@ interface ProductReferenceFormProps {
   showColumnMenu: boolean;
   onToggleColumnMenu: () => void;
   onToggleColumn: (key: string) => void;
-  onAdd: () => void;
   onSave: () => void;
   onBulkDelete: () => void;
   selectedCount: number;
@@ -20,7 +19,6 @@ function ProductReferenceForm({
   showColumnMenu,
   onToggleColumnMenu,
   onToggleColumn,
-  onAdd,
   onSave,
   onBulkDelete,
   selectedCount,
@@ -54,7 +52,6 @@ function ProductReferenceForm({
               </div>
             )}
           </div>
-          {/* Bouton Ajouter masqué — les produits proviennent d'Odoo */}
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {selectedCount > 0 && (

--- a/frontend/src/components/__tests__/ProductReference.test.tsx
+++ b/frontend/src/components/__tests__/ProductReference.test.tsx
@@ -81,7 +81,6 @@ describe('ProductReference', () => {
   it('renders the toolbar buttons', () => {
     renderProductReference();
     expect(screen.getByText('Colonnes')).toBeInTheDocument();
-    expect(screen.getByText('Ajouter')).toBeInTheDocument();
     expect(screen.getByText('Enregistrer')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/__tests__/ProductReferenceForm.test.tsx
+++ b/frontend/src/components/__tests__/ProductReferenceForm.test.tsx
@@ -18,7 +18,6 @@ const defaultProps = {
   showColumnMenu: false,
   onToggleColumnMenu: vi.fn(),
   onToggleColumn: vi.fn(),
-  onAdd: vi.fn(),
   onSave: vi.fn(),
   onBulkDelete: vi.fn(),
   selectedCount: 0,
@@ -30,11 +29,6 @@ describe('ProductReferenceForm', () => {
   it('renders Colonnes button', () => {
     render(<ProductReferenceForm {...defaultProps} />);
     expect(screen.getByText('Colonnes')).toBeInTheDocument();
-  });
-
-  it('renders Ajouter button', () => {
-    render(<ProductReferenceForm {...defaultProps} />);
-    expect(screen.getByText('Ajouter')).toBeInTheDocument();
   });
 
   it('renders Enregistrer button', () => {
@@ -89,14 +83,6 @@ describe('ProductReferenceForm', () => {
     );
     await user.click(screen.getByText('Colonnes'));
     expect(onToggleColumnMenu).toHaveBeenCalledOnce();
-  });
-
-  it('calls onAdd when clicking Ajouter', async () => {
-    const user = userEvent.setup();
-    const onAdd = vi.fn();
-    render(<ProductReferenceForm {...defaultProps} onAdd={onAdd} />);
-    await user.click(screen.getByText('Ajouter'));
-    expect(onAdd).toHaveBeenCalledOnce();
   });
 
   it('calls onSave when clicking Enregistrer', async () => {


### PR DESCRIPTION
## Summary
- Remove unused `onAdd` prop and `handleAdd` function from ProductReference components (the "Ajouter" button was already hidden since products come from Odoo)
- Fix 3 failing frontend tests that still referenced the removed button
- Clean up obsolete comment

## Test plan
- [x] All 125 frontend tests pass (13/13 test files)
- [x] All 162 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)