### PR TITLE
fix(db): repair missing supplier_id column in production

### DIFF
--- a/backend/alembic/versions/g1a2b3c4d5e9_repair_supplier_id_column.py
+++ b/backend/alembic/versions/g1a2b3c4d5e9_repair_supplier_id_column.py
@@ -1,0 +1,30 @@
+"""repair: ensure supplier_id column exists on product_calculations
+
+Revision ID: g1a2b3c4d5e9
+Revises: f2a2b3c4d5e8
+Create Date: 2026-02-14 15:50:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "g1a2b3c4d5e9"
+down_revision: Union[str, Sequence[str], None] = "f2a2b3c4d5e8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add supplier_id to product_calculations if missing (repair)."""
+    op.execute("""
+        ALTER TABLE product_calculations
+        ADD COLUMN IF NOT EXISTS supplier_id INTEGER REFERENCES suppliers(id)
+    """)
+
+
+def downgrade() -> None:
+    """Remove supplier_id from product_calculations."""
+    op.drop_column("product_calculations", "supplier_id")


### PR DESCRIPTION
## Summary
- Production `product_calculations` table is missing the `supplier_id` column
- Root cause: migration `07a9aef9ee3b` was stamped in alembic_version but DDL was never executed
- This caused 500 errors on both `POST /calculate_products` and `GET /product_price_summary`
- Adds a repair migration using `ADD COLUMN IF NOT EXISTS` (idempotent, safe for both envs)

## Test plan
- [x] 174 backend tests pass
- [x] Migration file parses correctly
- [x] `IF NOT EXISTS` ensures no error if column already exists (dev/test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)