### PR TITLE
fix(db): repair all missing columns on product_calculations

### DIFF
--- a/backend/alembic/versions/g1a2b3c4d5e9_repair_supplier_id_column.py
+++ b/backend/alembic/versions/g1a2b3c4d5e9_repair_supplier_id_column.py
@@ -1,4 +1,4 @@
-"""repair: ensure supplier_id column exists on product_calculations
+"""repair: ensure all columns exist on product_calculations
 
 Revision ID: g1a2b3c4d5e9
 Revises: f2a2b3c4d5e8
@@ -18,13 +18,24 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Add supplier_id to product_calculations if missing (repair)."""
-    op.execute("""
-        ALTER TABLE product_calculations
-        ADD COLUMN IF NOT EXISTS supplier_id INTEGER REFERENCES suppliers(id)
-    """)
+    """Repair product_calculations: add all potentially missing columns."""
+    columns = [
+        "ADD COLUMN IF NOT EXISTS supplier_id INTEGER REFERENCES suppliers(id)",
+        "ADD COLUMN IF NOT EXISTS price DOUBLE PRECISION NOT NULL DEFAULT 0",
+        "ADD COLUMN IF NOT EXISTS tcp DOUBLE PRECISION NOT NULL DEFAULT 0",
+        "ADD COLUMN IF NOT EXISTS marge4_5 DOUBLE PRECISION NOT NULL DEFAULT 0",
+        "ADD COLUMN IF NOT EXISTS marge DOUBLE PRECISION",
+        "ADD COLUMN IF NOT EXISTS marge_percent DOUBLE PRECISION",
+        "ADD COLUMN IF NOT EXISTS prixht_tcp_marge4_5 DOUBLE PRECISION NOT NULL DEFAULT 0",
+        "ADD COLUMN IF NOT EXISTS prixht_marge4_5 DOUBLE PRECISION NOT NULL DEFAULT 0",
+        "ADD COLUMN IF NOT EXISTS prixht_max DOUBLE PRECISION NOT NULL DEFAULT 0",
+        "ADD COLUMN IF NOT EXISTS date TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now()",
+        "ADD COLUMN IF NOT EXISTS stock INTEGER",
+    ]
+    for col in columns:
+        op.execute(f"ALTER TABLE product_calculations {col}")
 
 
 def downgrade() -> None:
-    """Remove supplier_id from product_calculations."""
-    op.drop_column("product_calculations", "supplier_id")
+    """No-op: cannot safely remove columns that may have existed before."""
+    pass


### PR DESCRIPTION
## Summary
- Production `product_calculations` table is missing ALL columns except `id` and `product_id`
- Previous repair only added `supplier_id`, now adding all 11 missing columns
- Uses `ADD COLUMN IF NOT EXISTS` for each column (idempotent, safe for all envs)

## Test plan
- [x] 174 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)