### PR TITLE
feat: filtres matching + stats produit par fournisseur

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -241,3 +241,24 @@ Renommage de la table `temporary_imports` en `supplier_catalog` pour mieux refle
 - **Documentation** : ARCHITECTURE.md, api_supplier_sync.md, LLM.md, fonctionnalites_app.md, ROADMAP.md mis a jour
 
 Fichiers concernes : `backend/models.py`, `backend/routes/products.py`, `backend/routes/matching.py`, `backend/utils/etl.py`, `backend/utils/calculations.py`, `backend/utils/llm_matching.py`, `frontend/src/api.ts`, `frontend/src/components/SearchPage.tsx`
+
+---
+
+# Prochaines etapes
+
+## ~~1. Ameliorations vue Rapprochement LLM~~ (implementee)
+- ~~ajouter pagination en bas de page~~
+- ~~ajouter un filtre par statut (pending, validated, rejected, created)~~
+- ~~quand on valide un produit, pas remonter en haut de page mais rester sur la meme endroit de la page~~
+- ~~quand on rejette un produit, pas remonter en haut de page mais rester sur la meme endroit de la page~~
+- ~~ajouter un filtre par modele de produit~~
+
+## 2. Ajouter un systeme de logs pour le backend
+## 3. Meilleures gestions de toutes les filtres des tableaux
+- Filtre ascendant/descendant
+- choix case à cocher par colonne
+- pouvoir taper dans les filtres pour choisis (comme dans excel)
+
+## 4. Dans le referentiel produit il y a des doublons :
+- memoire "512 Go" VS "512GB"
+- RAM : "4" VS "4Go"

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -866,11 +866,13 @@ export async function runMatching(supplierId?: number, limit?: number) {
   }
 }
 
-export async function fetchPendingMatches(params?: { supplier_id?: number; page?: number; per_page?: number }) {
+export async function fetchPendingMatches(params?: { supplier_id?: number; page?: number; per_page?: number; status?: string; model?: string }) {
   const search = new URLSearchParams();
   if (params?.supplier_id) search.set('supplier_id', String(params.supplier_id));
   if (params?.page) search.set('page', String(params.page));
   if (params?.per_page) search.set('per_page', String(params.per_page));
+  if (params?.status) search.set('status', params.status);
+  if (params?.model) search.set('model', params.model);
   const qs = search.toString();
   const res = await fetchWithAuth(`${API_BASE}/matching/pending${qs ? `?${qs}` : ''}`);
   if (!res.ok) {


### PR DESCRIPTION
## Summary

- **Filtres vue Rapprochement LLM** : ajout filtre par statut (pending/validated/rejected/created), filtre par modèle avec debounce, pagination en bas de page, préservation du scroll après validation/rejet, masquage des boutons d'action en mode lecture seule
- **Statistiques** : ajout filtre par produit et graphique de comparaison prix par fournisseur pour un produit spécifique, dropdown dédupliqué basé sur le modèle
- **Backend** : nouveaux paramètres `status` et `model` sur `GET /matching/pending` avec validation, filtre `product_id` sur l'évolution des prix

## Test plan

- [ ] Vérifier les filtres statut et modèle sur la vue Rapprochement LLM
- [ ] Vérifier la pagination en bas de page
- [ ] Valider/rejeter un match et confirmer que le scroll ne remonte pas
- [ ] Vérifier le filtre produit sur la page Statistiques
- [ ] `cd backend && python -m pytest tests/ -v` (188 passed)
- [ ] `cd frontend && npm test` (138 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)