### PR TITLE
feat(matching): expose unprocessed catalog count and highlight it in …

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -822,6 +822,7 @@ export interface MatchingStatsData {
   total_auto_matched: number;
   total_manual: number;
   cache_hit_rate: number;
+  total_catalog_unprocessed: number;
   by_supplier: {
     supplier_id: number;
     name: string;

--- a/frontend/src/components/MatchingPanel.tsx
+++ b/frontend/src/components/MatchingPanel.tsx
@@ -306,6 +306,24 @@ function MatchingPanel() {
         )}
       </div>
 
+      {/* Produits catalogue non encore traites */}
+      {stats && stats.total_catalog_unprocessed > 0 && (
+        <div className="flex items-center gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+          <span className="text-amber-400 text-lg font-bold shrink-0">
+            {stats.total_catalog_unprocessed}
+          </span>
+          <div>
+            <p className="text-sm font-medium text-amber-300">
+              produit{stats.total_catalog_unprocessed > 1 ? 's' : ''} du catalogue non encore rapproche{stats.total_catalog_unprocessed > 1 ? 's' : ''}
+            </p>
+            <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
+              Ces produits fournisseurs n'ont jamais ete inclus dans un lot de rapprochement LLM.
+              Lancez une association automatique pour les traiter.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Suivi de progression */}
       {stats && (
         <div className="card space-y-4">


### PR DESCRIPTION
…stats panel

Query SupplierCatalog entries with no PendingMatch and no SupplierProductRef to count products never included in an LLM matching batch. Surface this as total_catalog_unprocessed in the stats API and render an amber alert banner in MatchingPanel when unprocessed products remain.