### PR TITLE
fix(matching): exclude null product_id refs from matched_keys to unbl…

### DIFF
--- a/backend/utils/llm_matching.py
+++ b/backend/utils/llm_matching.py
@@ -557,7 +557,9 @@ def run_matching_job(
     if all_temp_imports:
         supplier_ids = {ti.supplier_id for ti in all_temp_imports if ti.supplier_id}
         for sid in supplier_ids:
-            refs = SupplierProductRef.query.filter_by(supplier_id=sid).all()
+            refs = SupplierProductRef.query.filter_by(supplier_id=sid).filter(
+                SupplierProductRef.product_id.isnot(None)
+            ).all()
             for ref in refs:
                 matched_keys.add((sid, ref.ean, ref.part_number))
 


### PR DESCRIPTION
…ock re-matching after reset

supplier_product_refs with product_id=NULL (detached by a full reset) were being included in matched_keys, causing all catalog entries for those suppliers to be silently skipped as "already matched". Only consider refs with a non-null product_id as actually matched.