### PR TITLE
feat(matching): enrich candidates on-the-fly and show product ID in UI

### DIFF
--- a/frontend/src/components/MatchingPanel.tsx
+++ b/frontend/src/components/MatchingPanel.tsx
@@ -687,8 +687,13 @@ function PendingMatchRow({
                 </span>
               </div>
               <div className="flex-1 min-w-0">
-                <div className="text-[var(--color-text-primary)] truncate">
-                  {c.product_name}
+                <div className="flex items-baseline gap-2">
+                  <span className="text-[var(--color-text-primary)] truncate">
+                    {c.product_name}
+                  </span>
+                  <span className="text-[10px] text-[var(--color-text-muted)] shrink-0">
+                    #{c.product_id}
+                  </span>
                 </div>
                 <ScoreDetails details={c.details} />
               </div>


### PR DESCRIPTION
list_pending now rebuilds candidate product_name at serve time via a single batch Product query — fixes stale names for existing PendingMatch records and ensures memory + color always appear regardless of when the match was created.

UI: show product ID (#42) next to each candidate name so identical model names (e.g. two "iPhone 16") can be traced back to the DB record.