### PR TITLE
feat(matching): expose last run result and improve completion feedback

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -838,6 +838,17 @@ export interface MatchingStatsData {
     matched: number;
     manual: number;
   }[];
+  last_run?: {
+    status: 'running' | 'completed' | 'error';
+    ran_at: string;
+    total_products?: number;
+    auto_matched?: number;
+    pending_review?: number;
+    auto_rejected?: number;
+    not_found?: number;
+    errors?: number;
+    error_message?: string | null;
+  } | null;
 }
 
 export interface CacheEntry {


### PR DESCRIPTION
- Store last run status/result in _last_run_result (backend) and expose it via /matching/stats as last_run field
- Log job completion with key counts (auto, review, rejected, not_found, errors) for observability
- Replace total_processed stability detection with last_run.status + ran_at comparison for reliable job completion signaling
- Show a result banner after polling stops: specific message when nothing was processed, error details on failure, counts on success