### PR TITLE
feat(nightly): add in-progress banner and polling after manual trigger

### DIFF
--- a/frontend/src/components/__tests__/NightlyPipelinePanel.test.tsx
+++ b/frontend/src/components/__tests__/NightlyPipelinePanel.test.tsx
@@ -133,14 +133,14 @@ describe('NightlyPipelinePanel', () => {
     });
   });
 
-  it('shows success message after trigger', async () => {
+  it('shows in-progress banner after trigger', async () => {
     mockTrigger.mockResolvedValue({ status: 'triggered' });
     renderPanel();
     await waitFor(() => screen.getByText('Lancer maintenant'));
 
     fireEvent.click(screen.getByText('Lancer maintenant'));
     await waitFor(() => {
-      expect(screen.getByText('Pipeline lancé en arrière-plan.')).toBeInTheDocument();
+      expect(screen.getByText(/Pipeline en cours/)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Replace the invisible muted text feedback with a persistent banner showing pipeline status. Poll fetchNightlyJobs every 5s after trigger, auto-refresh the history table, and display success/error state when the job completes.