### PR TITLE
docs: update README, ROADMAP and VUES.md for DRY refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ ajtpro/
 │   │   │   ├── TranslationAdmin.tsx       # Admin traductions/couleurs
 │   │   │   ├── UserAdmin.tsx              # Admin utilisateurs
 │   │   │   └── WeekToolbar.tsx            # Barre d'outils hebdomadaire
+│   │   ├── hooks/
+│   │   │   └── useProductAttributeOptions.ts  # Hook partage : chargement des options produit (marques, couleurs, etc.)
 │   │   ├── utils/
 │   │   │   ├── date.ts          # Fonctions de date
 │   │   │   ├── html.ts          # Generation HTML
@@ -334,7 +336,7 @@ Automatisation complete du cycle de synchronisation et de matching, declenchable
 - **Orchestration** : sync Odoo → sync API fournisseurs → re-evaluation matching LLM → rapport email
 - **Re-matching intelligent** : chaque nuit, tous les produits sont re-scores contre le catalogue mis a jour. Les extractions LLM passees sont preservees dans le `LabelCache` (bibliotheque historique) pour eviter les appels API redondants. Les matches identiques a la veille sont auto-valides ; les matches changes passent en attente de validation
 - **Declenchement manuel** : bouton "Lancer maintenant" avec suivi du job en temps reel
-- **Planificateur** : `threading.Timer` verifiant chaque minute si l'heure configuree est atteinte (UTC). Active via `ENABLE_NIGHTLY_SCHEDULER=true`
+- **Planificateur** : `threading.Timer` verifiant chaque minute si l'heure configuree est atteinte (UTC). L'interface affiche l'heure en fuseau Europe/Paris avec conversion automatique. Active via `ENABLE_NIGHTLY_SCHEDULER=true`
 - **Rapport email** : webhook n8n (POST JSON) → workflow Gmail. Contient le statut, les compteurs (produits Odoo, fournisseurs, labels), la duree et un lien vers la page de validation
 - **Gestion des destinataires** : CRUD des adresses email depuis l'interface admin
 - **Historique** : 20 derniers jobs avec statut, date, duree et compteurs
@@ -460,7 +462,7 @@ Le gabarit OpenAPI se trouve dans `backend/swagger_template.yml`.
 
 ### Tests backend
 
-Le framework `pytest` est configure dans le backend (SQLite in-memory, pas besoin de PostgreSQL) — 279 tests dans 16 fichiers :
+Le framework `pytest` est configure dans le backend (SQLite in-memory, pas besoin de PostgreSQL) — 314 tests dans 16 fichiers :
 
 ```bash
 cd backend
@@ -470,7 +472,7 @@ python -m pytest tests/ -v
 
 ### Tests frontend
 
-Le framework `vitest` avec Testing Library est configure dans le frontend — 175 tests dans 18 fichiers :
+Le framework `vitest` avec Testing Library est configure dans le frontend — 186 tests dans 18 fichiers :
 
 ```bash
 cd frontend

--- a/docs/VUES.md
+++ b/docs/VUES.md
@@ -565,7 +565,7 @@ Interface complète de gestion du pipeline nightly automatisé (`NightlyPipeline
 | Champ | Source | Description |
 |-------|--------|-------------|
 | Activer le scheduler | `nightly_config.enabled` | Toggle on/off du planificateur automatique |
-| Heure d'exécution | `nightly_config.run_hour` | Heure UTC (0-23) à laquelle le pipeline se déclenche chaque nuit |
+| Heure d'exécution | `nightly_config.run_hour` | Heure affichée en heure de Paris (Europe/Paris), stockée en UTC en base. La conversion UTC↔Paris est faite côté frontend (`utcToParisHour` / `parisHourToUtc` dans `NightlyPipelinePanel.tsx`) |
 
 Endpoint : `GET/PUT /nightly/config`
 
@@ -614,7 +614,7 @@ Endpoint : `GET/POST /nightly/recipients` + `DELETE /nightly/recipients/<id>`
 
 - **`ENABLE_NIGHTLY_SCHEDULER=true`** requis pour que le scheduler se lance au démarrage du backend. Sans cette variable, le pipeline ne s'exécute jamais automatiquement (lancement manuel toujours possible).
 - **`NIGHTLY_WEBHOOK_URL`** : URL du webhook n8n pour l'envoi de l'email. Si absent, l'email est simplement ignoré (pas d'erreur bloquante).
-- **Heure UTC** : configurer l'heure en UTC. Par exemple, pour 3h du matin en France (UTC+1 hiver), configurer `run_hour=2`.
+- **Heure Paris** : l'interface affiche et accepte l'heure en fuseau Europe/Paris. La conversion vers UTC est automatique (le backend et le scheduler fonctionnent en UTC). Ex : configurer "03:00" dans l'interface → stocké `run_hour=2` en hiver (UTC+1) ou `run_hour=1` en été (UTC+2).
 - **Résilience** : au démarrage du serveur, `_cleanup_orphaned_jobs()` remet à `failed` tous les jobs bloqués en `running` (crashs, hot-reload Werkzeug).
 - **Fréquence** : la variable `_last_run_date` empêche le pipeline de se déclencher plusieurs fois la même nuit UTC, même si le serveur redémarre.
 - **Flux nightly vs manuel** : en mode nightly, `skip_already_matched=True` contourne l'exclusion `product_calculations`/`LabelCache`. En mode manuel (UI Rapprochement), l'exclusion normale s'applique (évite de re-soumettre les produits déjà matchés).


### PR DESCRIPTION
## Summary

- Mark DRY violations as implemented in ROADMAP (backend helpers + frontend hook + mergeOptions removal)
- Update VUES.md nightly section for Paris timezone display
- Add `hooks/` directory to README structure
- Update test counts (314 backend, 186 frontend)

## Test plan

- [x] Documentation-only changes, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)