### PR TITLE
feat(infra): serve static catalogue page via Nginx

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,8 @@ services:
     container_name: ajt_frontend_prod
     environment:
       - VITE_API_BASE=https://ajtpro.api.tulip-saas.fr
+    volumes:
+      - ./catalogue:/usr/share/nginx/html/catalogue:ro
     ports:
       - "3000:80"
     networks:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -26,6 +26,13 @@ server {
         access_log off;
     }
 
+    # Catalogue statique (page publique indépendante de React)
+    location /catalogue {
+        alias /usr/share/nginx/html/catalogue;
+        index index.html;
+        try_files $uri $uri/ /catalogue/index.html;
+    }
+
     # Gestion du routing React
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Mount catalogue/ directory into frontend container and add Nginx location /catalogue block before React catch-all so the static product catalogue is served at /catalogue.