### PR TITLE
refactor(quality): fix empty catches, replace any types and extract shared mapping helper

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -326,7 +326,7 @@ export async function fetchSupplierApiReports(limit = 20) {
   return res.json() as Promise<SupplierApiReportEntry[]>;
 }
 
-export async function createProduct(data: any) {
+export async function createProduct(data: Record<string, unknown>) {
   return crudRequest('POST', `${API_BASE}/products`, data);
 }
 
@@ -378,11 +378,11 @@ export async function deleteSupplierApiField(fieldId: number) {
   return crudRequest('DELETE', `${API_BASE}/supplier_api/fields/${fieldId}`);
 }
 
-export async function updateProduct(id: number, data: any) {
+export async function updateProduct(id: number, data: Record<string, unknown>) {
   return crudRequest('PUT', `${API_BASE}/products/${id}`, data);
 }
 
-export async function bulkUpdateProducts(data: any[]) {
+export async function bulkUpdateProducts(data: Record<string, unknown>[]) {
   return crudRequest('PUT', `${API_BASE}/products/bulk_update`, data);
 }
 
@@ -519,11 +519,11 @@ export async function fetchReferenceTable(table: string) {
   return res.json();
 }
 
-export async function updateReferenceItem(table: string, id: number, data: any) {
+export async function updateReferenceItem(table: string, id: number, data: Record<string, unknown>) {
   return crudRequest('PUT', `${API_BASE}/references/${table}/${id}`, data);
 }
 
-export async function createReferenceItem(table: string, data: any) {
+export async function createReferenceItem(table: string, data: Record<string, unknown>) {
   return crudRequest('POST', `${API_BASE}/references/${table}`, data);
 }
 
@@ -539,11 +539,11 @@ export async function fetchUsers() {
   return res.json();
 }
 
-export async function updateUser(id: number, data: any) {
+export async function updateUser(id: number, data: Record<string, unknown>) {
   return crudRequest('PUT', `${API_BASE}/users/${id}`, data);
 }
 
-export async function createUser(data: any) {
+export async function createUser(data: Record<string, unknown>) {
   return crudRequest('POST', `${API_BASE}/users`, data);
 }
 

--- a/frontend/src/components/ProductAdmin.tsx
+++ b/frontend/src/components/ProductAdmin.tsx
@@ -35,7 +35,7 @@ function ProductAdmin() {
     try {
       const res = await fetchProducts();
       setProducts(
-        (res as any[]).map((p) => ({
+        (res as Record<string, unknown>[]).map((p) => ({
           id: p.id,
           ean: p.ean ?? '',
           model: p.model ?? '',
@@ -86,8 +86,8 @@ function ProductAdmin() {
         notify('Produit mis à jour', 'success');
       }
       await load();
-    } catch {
-      /* empty */
+    } catch (err) {
+      notify(err instanceof Error ? err.message : 'Erreur de sauvegarde', 'error');
     }
   };
 
@@ -100,8 +100,8 @@ function ProductAdmin() {
         notify('Produit supprimé', 'success');
         await load();
       }
-    } catch {
-      /* empty */
+    } catch (err) {
+      notify(err instanceof Error ? err.message : 'Erreur de suppression', 'error');
     }
   };
 

--- a/frontend/src/components/ReferenceAdmin.tsx
+++ b/frontend/src/components/ReferenceAdmin.tsx
@@ -38,8 +38,8 @@ const FIELD_LABELS: Record<string, string> = {
 
 function ReferenceAdmin({ isVisible, onClose }: ReferenceAdminProps) {
   const [table, setTable] = useState<string | null>(null);
-  const [data, setData] = useState<any[]>([]);
-  const [suppliers, setSuppliers] = useState<any[]>([]);
+  const [data, setData] = useState<Record<string, unknown>[]>([]);
+  const [suppliers, setSuppliers] = useState<Record<string, unknown>[]>([]);
   const notify = useNotification();
 
   useEffect(() => {
@@ -51,7 +51,7 @@ function ReferenceAdmin({ isVisible, onClose }: ReferenceAdminProps) {
   useEffect(() => {
     if (table === 'format_imports') {
       fetchSuppliers()
-        .then((s) => setSuppliers(s as any[]))
+        .then((s) => setSuppliers(s as Record<string, unknown>[]))
         .catch(() => setSuppliers([]));
     }
   }, [table]);
@@ -59,7 +59,7 @@ function ReferenceAdmin({ isVisible, onClose }: ReferenceAdminProps) {
   const load = async (t: string) => {
     try {
       const res = await fetchReferenceTable(t);
-      setData(res as any[]);
+      setData(res as Record<string, unknown>[]);
     } catch {
       setData([]);
     }
@@ -74,7 +74,7 @@ function ReferenceAdmin({ isVisible, onClose }: ReferenceAdminProps) {
   const handleSave = async (id: number) => {
     const item = data.find((d) => d.id === id);
     if (!item) return;
-    const payload: Record<string, any> = { ...item };
+    const payload: Record<string, unknown> = { ...item };
     delete payload.id;
     try {
       if (id < 0) {
@@ -100,14 +100,14 @@ function ReferenceAdmin({ isVisible, onClose }: ReferenceAdminProps) {
         notify('Entrée supprimée', 'success');
         await load(table!);
       }
-    } catch {
-      /* empty */
+    } catch (err) {
+      notify(err instanceof Error ? err.message : 'Erreur de suppression', 'error');
     }
   };
 
   const handleAdd = () => {
     const fields = data.length > 0 ? Object.keys(data[0]).filter((k) => k !== 'id') : [];
-    const newItem: any = { id: Date.now() * -1 };
+    const newItem: Record<string, unknown> = { id: Date.now() * -1 };
     fields.forEach((f) => (newItem[f] = ''));
     setData((prev) => [...prev, newItem]);
   };

--- a/frontend/src/components/TranslationAdmin.tsx
+++ b/frontend/src/components/TranslationAdmin.tsx
@@ -20,8 +20,8 @@ const TABLES = [
 
 function TranslationAdmin({ isVisible, onClose }: TranslationAdminProps) {
   const [table, setTable] = useState<string | null>(null);
-  const [data, setData] = useState<any[]>([]);
-  const [colors, setColors] = useState<any[]>([]);
+  const [data, setData] = useState<Record<string, unknown>[]>([]);
+  const [colors, setColors] = useState<Record<string, unknown>[]>([]);
   const notify = useNotification();
 
   useEffect(() => {
@@ -37,15 +37,15 @@ function TranslationAdmin({ isVisible, onClose }: TranslationAdminProps) {
           fetchReferenceTable(t),
           fetchColors(),
         ]);
-        setColors(cols as any[]);
-        const mapped = (translations as any[]).map((item) => {
-          const c = (cols as any[]).find((cc) => cc.color === item.color_target);
+        setColors(cols as Record<string, unknown>[]);
+        const mapped = (translations as Record<string, unknown>[]).map((item) => {
+          const c = (cols as Record<string, unknown>[]).find((cc) => cc.color === item.color_target);
           return { ...item, color_target_id: c ? c.id : '' };
         });
         setData(mapped);
       } else {
         const res = await fetchReferenceTable(t);
-        setData(res as any[]);
+        setData(res as Record<string, unknown>[]);
       }
     } catch {
       setData([]);
@@ -71,7 +71,7 @@ function TranslationAdmin({ isVisible, onClose }: TranslationAdminProps) {
   const handleSave = async (id: number) => {
     const item = data.find((d) => d.id === id);
     if (!item) return;
-    const payload: Record<string, any> = { ...item };
+    const payload: Record<string, unknown> = { ...item };
     delete payload.id;
     try {
       if (id < 0) {
@@ -82,8 +82,8 @@ function TranslationAdmin({ isVisible, onClose }: TranslationAdminProps) {
         notify('Entrée mise à jour', 'success');
       }
       await load(table!);
-    } catch {
-      /* empty */
+    } catch (err) {
+      notify(err instanceof Error ? err.message : 'Erreur de sauvegarde', 'error');
     }
   };
 
@@ -96,15 +96,15 @@ function TranslationAdmin({ isVisible, onClose }: TranslationAdminProps) {
         notify('Entrée supprimée', 'success');
         await load(table!);
       }
-    } catch {
-      /* empty */
+    } catch (err) {
+      notify(err instanceof Error ? err.message : 'Erreur de suppression', 'error');
     }
   };
 
   const handleAdd = () => {
     const fields =
       data.length > 0 ? Object.keys(data[0]).filter((k) => k !== 'id') : [];
-    const newItem: any = { id: Date.now() * -1 };
+    const newItem: Record<string, unknown> = { id: Date.now() * -1 };
     fields.forEach((f) => (newItem[f] = ''));
     if (table === 'color_translations') {
       newItem.color_target_id = colors[0]?.id ?? '';


### PR DESCRIPTION
## Summary

- Fix 5 silenced catches in ProductAdmin, ReferenceAdmin, TranslationAdmin → proper error notifications via `notify()`
- Replace ~15 `any` types with `Record<string, unknown>` across `api.ts` and admin components
- Extract duplicated `_select_best_mapping` / `_select_mapping` into shared `select_best_mapping()` in `utils/etl.py`

## Test plan

- [x] Backend tests: 319/319 passing
- [x] Frontend tests: 186/186 passing
- [x] TypeScript compiles clean (no errors)
- [ ] Visual check: admin pages (Products, References, Translations) show error notifications on save/delete failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)