### PR TITLE
refactor(ui): extract useAdminCrud hook to DRY admin components

### DIFF
--- a/frontend/src/components/TranslationAdmin.tsx
+++ b/frontend/src/components/TranslationAdmin.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { ArrowLeft, Save, Trash2, Plus } from 'lucide-react';
 import {
   fetchReferenceTable,
-  updateReferenceItem,
   createReferenceItem,
   deleteReferenceItem,
+  updateReferenceItem,
   fetchColors
 } from '../api';
-import { useNotification } from './NotificationProvider';
+import { useAdminCrud } from '../hooks/useAdminCrud';
 
 interface TranslationAdminProps {
   onClose: () => void;
@@ -18,100 +18,45 @@ const TABLES = [
   { key: 'color_translations', label: 'Cohérence des couleurs' },
 ];
 
-function TranslationAdmin({ isVisible, onClose }: TranslationAdminProps) {
+function TranslationAdmin({ isVisible }: TranslationAdminProps) {
   const [table, setTable] = useState<string | null>(null);
-  const [data, setData] = useState<Record<string, unknown>[]>([]);
   const [colors, setColors] = useState<Record<string, unknown>[]>([]);
-  const notify = useNotification();
 
-  useEffect(() => {
-    if (isVisible && table) {
-      load(table);
-    }
-  }, [isVisible, table]);
-
-  const load = async (t: string) => {
-    try {
-      if (t === 'color_translations') {
-        const [translations, cols] = await Promise.all([
-          fetchReferenceTable(t),
-          fetchColors(),
-        ]);
-        setColors(cols as Record<string, unknown>[]);
-        const mapped = (translations as Record<string, unknown>[]).map((item) => {
-          const c = (cols as Record<string, unknown>[]).find((cc) => cc.color === item.color_target);
-          return { ...item, color_target_id: c ? c.id : '' };
-        });
-        setData(mapped);
-      } else {
-        const res = await fetchReferenceTable(t);
-        setData(res as Record<string, unknown>[]);
-      }
-    } catch {
-      setData([]);
-    }
-  };
-
-  const handleChange = (id: number, field: string, value: string) => {
-    setData((prev) =>
-      prev.map((item) => {
-        if (item.id !== id) return item;
-        const updated = { ...item, [field]: value };
-        if (table === 'color_translations' && field === 'color_target_id') {
-          const col = colors.find((c) => String(c.id) === value);
-          if (col) {
-            updated.color_target = col.color;
-          }
-        }
-        return updated;
-      })
-    );
-  };
-
-  const handleSave = async (id: number) => {
-    const item = data.find((d) => d.id === id);
-    if (!item) return;
-    const payload: Record<string, unknown> = { ...item };
-    delete payload.id;
-    try {
-      if (id < 0) {
-        await createReferenceItem(table!, payload);
-        notify('Entrée créée', 'success');
-      } else {
-        await updateReferenceItem(table!, id, payload);
-        notify('Entrée mise à jour', 'success');
-      }
-      await load(table!);
-    } catch (err) {
-      notify(err instanceof Error ? err.message : 'Erreur de sauvegarde', 'error');
-    }
-  };
-
-  const handleDelete = async (id: number) => {
-    try {
-      if (id < 0) {
-        setData((prev) => prev.filter((i) => i.id !== id));
-      } else {
-        await deleteReferenceItem(table!, id);
-        notify('Entrée supprimée', 'success');
-        await load(table!);
-      }
-    } catch (err) {
-      notify(err instanceof Error ? err.message : 'Erreur de suppression', 'error');
-    }
-  };
-
-  const handleAdd = () => {
-    const fields =
-      data.length > 0 ? Object.keys(data[0]).filter((k) => k !== 'id') : [];
-    const newItem: Record<string, unknown> = { id: Date.now() * -1 };
-    fields.forEach((f) => (newItem[f] = ''));
+  const fetchFn = useCallback(async (): Promise<Record<string, unknown>[]> => {
+    if (!table) return [];
     if (table === 'color_translations') {
-      newItem.color_target_id = colors[0]?.id ?? '';
-      newItem.color_target = colors[0]?.color ?? '';
+      const [translations, cols] = await Promise.all([
+        fetchReferenceTable(table),
+        fetchColors(),
+      ]);
+      setColors(cols as Record<string, unknown>[]);
+      return (translations as Record<string, unknown>[]).map((item) => {
+        const c = (cols as Record<string, unknown>[]).find((cc) => cc.color === item.color_target);
+        return { ...item, color_target_id: c ? c.id : '' };
+      });
     }
-    setData((prev) => [...prev, newItem]);
-  };
+    return fetchReferenceTable(table).then((r) => r as Record<string, unknown>[]);
+  }, [table]);
+
+  const onFieldChange = useCallback(
+    (item: Record<string, unknown>, field: string, value: string) => {
+      if (table === 'color_translations' && field === 'color_target_id') {
+        const col = colors.find((c) => String(c.id) === value);
+        if (col) return { ...item, color_target: col.color };
+      }
+      return item;
+    },
+    [table, colors]
+  );
+
+  const { data, handleChange, handleSave, handleDelete, handleAdd } = useAdminCrud({
+    fetchFn,
+    createFn: (payload) => createReferenceItem(table!, payload),
+    updateFn: (id, payload) => updateReferenceItem(table!, id, payload),
+    deleteFn: (id) => deleteReferenceItem(table!, id),
+    onFieldChange,
+    enabled: isVisible && !!table,
+  });
 
   if (!isVisible) return null;
 
@@ -158,34 +103,34 @@ function TranslationAdmin({ isVisible, onClose }: TranslationAdminProps) {
             <div className="divide-y divide-[var(--color-border-subtle)]">
               {data.map((item) => (
                 <div key={item.id} className="flex items-center space-x-2 px-4 py-2">
-                  <span className="w-10 text-[var(--color-text-muted)] text-sm">{item.id > 0 ? item.id : '-'}</span>
+                  <span className="w-10 text-[var(--color-text-muted)] text-sm">{(item.id as number) > 0 ? item.id as number : '-'}</span>
                   {displayedFields.map((f) => (
                     <input
                       key={f}
-                      value={item[f] ?? ''}
+                      value={item[f] as string ?? ''}
                       placeholder={f}
-                      onChange={(e) => handleChange(item.id, f, e.target.value)}
+                      onChange={(e) => handleChange(item.id as number, f, e.target.value)}
                       className="flex-1 px-2 py-1 bg-[var(--color-bg-input)] text-[var(--color-text-primary)] rounded placeholder:italic text-sm"
                     />
                   ))}
                   {table === 'color_translations' && (
                     <select
-                      value={item.color_target_id ?? ''}
-                      onChange={(e) => handleChange(item.id, 'color_target_id', e.target.value)}
+                      value={item.color_target_id as string ?? ''}
+                      onChange={(e) => handleChange(item.id as number, 'color_target_id', e.target.value)}
                       className="flex-1 px-2 py-1 bg-[var(--color-bg-input)] text-[var(--color-text-primary)] rounded text-sm"
                     >
                       {colors.map((c) => (
-                        <option key={c.id} value={c.id}>
-                          {c.color}
+                        <option key={c.id as number} value={c.id as number}>
+                          {c.color as string}
                         </option>
                       ))}
                     </select>
                   )}
                   <div className="flex items-center gap-1">
-                    <button onClick={() => handleSave(item.id)} className="btn btn-primary p-1.5">
+                    <button onClick={() => handleSave(item.id as number)} className="btn btn-primary p-1.5">
                       <Save className="w-4 h-4" />
                     </button>
-                    <button onClick={() => handleDelete(item.id)} className="btn btn-secondary p-1.5 text-red-500">
+                    <button onClick={() => handleDelete(item.id as number)} className="btn btn-secondary p-1.5 text-red-500">
                       <Trash2 className="w-4 h-4" />
                     </button>
                   </div>

--- a/frontend/src/hooks/useAdminCrud.ts
+++ b/frontend/src/hooks/useAdminCrud.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useNotification } from '../components/NotificationProvider';
+
+interface UseAdminCrudOptions<T extends { id: number }> {
+  fetchFn: () => Promise<T[]>;
+  createFn: (payload: Record<string, unknown>) => Promise<unknown>;
+  updateFn: (id: number, payload: Record<string, unknown>) => Promise<unknown>;
+  deleteFn: (id: number) => Promise<unknown>;
+  initialItem?: Omit<T, 'id'>;
+  onFieldChange?: (item: T, field: string, value: string) => T;
+  confirmDelete?: boolean;
+  confirmDeleteMessage?: string;
+  enabled?: boolean;
+}
+
+interface UseAdminCrudReturn<T extends { id: number }> {
+  data: T[];
+  setData: Dispatch<SetStateAction<T[]>>;
+  handleChange: (id: number, field: string, value: string) => void;
+  handleSave: (id: number) => Promise<void>;
+  handleDelete: (id: number) => Promise<void>;
+  handleAdd: () => void;
+  reload: () => Promise<void>;
+}
+
+export function useAdminCrud<T extends { id: number }>(
+  options: UseAdminCrudOptions<T>
+): UseAdminCrudReturn<T> {
+  const {
+    createFn,
+    updateFn,
+    deleteFn,
+    initialItem,
+    onFieldChange,
+    confirmDelete = false,
+    confirmDeleteMessage = 'Supprimer cet élément ?',
+    enabled = true,
+  } = options;
+
+  const [data, setData] = useState<T[]>([]);
+  const notify = useNotification();
+
+  const fetchFnRef = useRef(options.fetchFn);
+  useEffect(() => {
+    fetchFnRef.current = options.fetchFn;
+  });
+
+  const load = useCallback(async () => {
+    try {
+      setData(await fetchFnRef.current());
+    } catch {
+      setData([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (enabled) {
+      load();
+    }
+  }, [enabled, options.fetchFn, load]);
+
+  const handleChange = useCallback(
+    (id: number, field: string, value: string) => {
+      setData((prev) =>
+        prev.map((item) => {
+          if (item.id !== id) return item;
+          const updated = { ...item, [field]: value };
+          return onFieldChange ? onFieldChange(updated, field, value) : updated;
+        })
+      );
+    },
+    [onFieldChange]
+  );
+
+  const handleSave = useCallback(
+    async (id: number) => {
+      const item = data.find((d) => d.id === id);
+      if (!item) return;
+      const payload: Record<string, unknown> = { ...item };
+      delete payload.id;
+      try {
+        if (id < 0) {
+          await createFn(payload);
+          notify('Entrée créée', 'success');
+        } else {
+          await updateFn(id, payload);
+          notify('Entrée mise à jour', 'success');
+        }
+        await load();
+      } catch (err) {
+        notify(err instanceof Error ? err.message : 'Erreur de sauvegarde', 'error');
+      }
+    },
+    [data, createFn, updateFn, load, notify]
+  );
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      if (id < 0) {
+        setData((prev) => prev.filter((i) => i.id !== id));
+        return;
+      }
+      if (confirmDelete && !window.confirm(confirmDeleteMessage)) return;
+      try {
+        await deleteFn(id);
+        notify('Entrée supprimée', 'success');
+        await load();
+      } catch (err) {
+        notify(err instanceof Error ? err.message : 'Erreur de suppression', 'error');
+      }
+    },
+    [confirmDelete, confirmDeleteMessage, deleteFn, load, notify]
+  );
+
+  const handleAdd = useCallback(() => {
+    const newItem = {
+      id: Date.now() * -1,
+      ...(initialItem ??
+        (data.length > 0
+          ? Object.fromEntries(
+              Object.keys(data[0])
+                .filter((k) => k !== 'id')
+                .map((k) => [k, ''])
+            )
+          : {})),
+    } as T;
+    setData((prev) => [...prev, newItem]);
+  }, [data, initialItem]);
+
+  return { data, setData, handleChange, handleSave, handleDelete, handleAdd, reload: load };
+}


### PR DESCRIPTION
## Summary

- Extract shared CRUD logic (state, load, save, delete, add, change) into a generic `useAdminCrud<T>` hook
- Migrate `UserAdmin`, `ReferenceAdmin`, and `TranslationAdmin` to use the hook
- Fix 2 silent empty catches and 1 `as any[]` in UserAdmin
- Net reduction: -13 lines across 4 files, with all mutation logic now centralized

## Test plan

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] All 186 frontend tests pass
- [ ] Visual: Admin > Utilisateurs — CRUD works (create, edit, delete with confirm)
- [ ] Visual: Admin > Références — all 9 tables CRUD works, supplier dropdown on format_imports
- [ ] Visual: Admin > Traductions — color_translations CRUD with color dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)