### PR TITLE
feat(products): bulk margin update with row selection, % mode and unit display

### DIFF
--- a/frontend/src/components/BulkMarginModal.tsx
+++ b/frontend/src/components/BulkMarginModal.tsx
@@ -1,21 +1,24 @@
 import { useState } from 'react';
 import { X } from 'lucide-react';
 
+export type MarginUnit = '€' | '%';
+
 interface BulkMarginModalProps {
   count: number;
-  onConfirm: (margin: number) => void;
+  onConfirm: (value: number, unit: MarginUnit) => void;
   onClose: () => void;
 }
 
 function BulkMarginModal({ count, onConfirm, onClose }: BulkMarginModalProps) {
   const [marginInput, setMarginInput] = useState('');
+  const [unit, setUnit] = useState<MarginUnit>('€');
 
-  const parsedMargin = parseFloat(marginInput.replace(',', '.'));
-  const isValid = !isNaN(parsedMargin) && parsedMargin >= 0;
+  const parsedValue = parseFloat(marginInput.replace(',', '.'));
+  const isValid = !isNaN(parsedValue) && parsedValue >= 0;
 
   const handleSubmit = () => {
     if (!isValid) return;
-    onConfirm(parsedMargin);
+    onConfirm(parsedValue, unit);
   };
 
   return (
@@ -32,22 +35,49 @@ function BulkMarginModal({ count, onConfirm, onClose }: BulkMarginModalProps) {
             <X className="w-4 h-4" />
           </button>
         </div>
+
+        <div className="mb-4">
+          <span className="block text-sm text-[var(--color-text-muted)] mb-2">Unité</span>
+          <div className="flex rounded-md overflow-hidden border border-[var(--color-border-strong)] w-fit">
+            {(['€', '%'] as MarginUnit[]).map((u) => (
+              <button
+                key={u}
+                type="button"
+                onClick={() => setUnit(u)}
+                className={`px-4 py-1.5 text-sm font-medium transition-colors ${
+                  unit === u
+                    ? 'bg-[#B8860B] text-white'
+                    : 'bg-[var(--color-bg-surface)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                {u}
+              </button>
+            ))}
+          </div>
+        </div>
+
         <div className="mb-5">
           <label className="block text-sm text-[var(--color-text-muted)] mb-1">
-            Nouvelle marge (€)
+            Nouvelle marge ({unit})
           </label>
-          <input
-            type="number"
-            min="0"
-            step="0.01"
-            value={marginInput}
-            onChange={(e) => setMarginInput(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
-            placeholder="Ex : 15"
-            className="w-full px-3 py-2 bg-[var(--color-bg-surface)] border border-[var(--color-border-strong)] rounded-md text-sm"
-            autoFocus
-          />
+          <div className="relative">
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={marginInput}
+              onChange={(e) => setMarginInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+              placeholder={unit === '%' ? 'Ex : 15' : 'Ex : 20'}
+              className="w-full px-3 py-2 pr-8 bg-[var(--color-bg-surface)] border border-[var(--color-border-strong)] rounded-md text-sm"
+              autoFocus
+            />
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-[var(--color-text-muted)] pointer-events-none">
+              {unit}
+            </span>
+          </div>
         </div>
+
         <div className="flex gap-2 justify-end">
           <button onClick={onClose} className="btn btn-secondary text-sm">
             Annuler

--- a/frontend/src/components/ProductTable.tsx
+++ b/frontend/src/components/ProductTable.tsx
@@ -126,12 +126,22 @@ function ProductTable({
                   col.key.startsWith('pa_') &&
                   typeof value === 'number' &&
                   value === minPrice;
+                const isEuroColumn =
+                  col.key === 'averagePrice' || col.key === 'marge' || col.key.startsWith('pa_');
+                const displayValue =
+                  value !== undefined && value !== null
+                    ? typeof value === 'number'
+                      ? isEuroColumn
+                        ? `${value} €`
+                        : String(value)
+                      : String(value)
+                    : '';
                 return (
                   <td
                     key={col.key}
                     className={`px-3 py-1 border-b border-[var(--color-border-default)] ${isMin ? 'text-green-400' : ''}`}
                   >
-                    {value !== undefined ? String(value) : ''}
+                    {displayValue}
                   </td>
                 );
               })}


### PR DESCRIPTION
## Summary
- Add checkboxes to TCP/Marges table rows with a select-all header checkbox
- When products are selected, a toolbar shows count, a deselect button and a "Maj des marges" button
- BulkMarginModal supports both € and % modes with a pill toggle; % mode computes per-product margin from base cost
- Price/margin/PA columns now display "€" suffix in cells for clarity

## Test plan
- [ ] Check and uncheck individual product rows — selection counter updates
- [ ] Use select-all checkbox to select/deselect current page
- [ ] Click "Désélectionner" — all checkboxes cleared
- [ ] Open "Maj des marges" modal, toggle between € and %
- [ ] Apply a €-margin: verify marge, marge_percent and prix de vente updated correctly
- [ ] Apply a %-margin: verify marge = baseCost × (% / 100), marge_percent = input value
- [ ] Confirm dialog shows correct unit (€ or %)
- [ ] Verify "€" suffix appears on Prix de vente, Marge and PA columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)