### PR TITLE
feat(catalogue): scroll to first product section on category filter

### DIFF
--- a/catalogue/js/app.js
+++ b/catalogue/js/app.js
@@ -145,11 +145,20 @@ function filterCategory(cat, btn) {
   document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
   btn.classList.add('active');
 
+  let firstVisible = null;
   document.querySelectorAll('.section').forEach(s => {
-    s.style.display = (cat === 'all' || s.dataset.cat === cat) ? '' : 'none';
+    const visible = cat === 'all' || s.dataset.cat === cat;
+    s.style.display = visible ? '' : 'none';
+    if (visible && !firstVisible) firstVisible = s;
   });
 
   document.querySelector('.nav-tabs').classList.remove('open');
+
+  if (firstVisible) {
+    const navHeight = document.querySelector('.nav').offsetHeight;
+    const top = firstVisible.getBoundingClientRect().top + window.scrollY - navHeight - 16;
+    window.scrollTo({ top, behavior: 'smooth' });
+  }
 }
 
 // ===== SCROLL REVEAL =====


### PR DESCRIPTION
## Summary
- When clicking a nav tab, the page smoothly scrolls to the top of the first visible section
- Offset accounts for the sticky nav height (64px) + 16px margin

## Test plan
- [ ] Click "Smartphones Renforcés" → page scrolls to that section
- [ ] Click "Tablettes" → page scrolls to that section
- [ ] Click "Tout" → page scrolls to the first section (Smartphones Renforcés)
- [ ] Mobile: hamburger menu closes before scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)