### PR TITLE
fix(catalogue): make dark color dots visible on dark background

### DIFF
--- a/catalogue/css/style.css
+++ b/catalogue/css/style.css
@@ -219,7 +219,7 @@ body {
 .color-dots { display:flex; gap:6px; }
 .color-dot {
   width:22px; height:22px; border-radius:50%;
-  border:2px solid transparent;
+  border:2px solid rgba(255,255,255,0.18);
   cursor:pointer; transition:all .25s;
   position:relative;
 }
@@ -296,7 +296,7 @@ body {
 .modal-color-dots { display:flex; gap:8px; }
 .modal-color-dot {
   width:28px; height:28px; border-radius:50%;
-  border:2px solid transparent;
+  border:2px solid rgba(255,255,255,0.18);
   cursor:pointer; transition:all .25s;
 }
 .modal-color-dot:hover, .modal-color-dot.active {


### PR DESCRIPTION
## Summary
- Color dots (card + modal) now have a permanent `rgba(255,255,255,0.18)` border
- Black dots (#1a1a1a) are now clearly visible against the dark card background
- Gold border on hover/active overrides the subtle ring as before

## Test plan
- [ ] Black color dot is visible on Hyper 7 Pro, T7, Cyber 13, etc.
- [ ] Gold ring still appears on hover and active dot
- [ ] Colored dots (red, orange, etc.) still look clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)