### PR TITLE
feat(catalogue): replace emojis with Tabler Icons

### DIFF
--- a/catalogue/css/style.css
+++ b/catalogue/css/style.css
@@ -133,7 +133,8 @@ body {
   display:flex; align-items:center; gap:16px;
   margin-bottom:8px;
 }
-.section-icon { font-size:28px; }
+.section-icon { font-size:28px; line-height:1; }
+.nav-tab i, .nav-shop i { font-size:15px; }
 .section-title {
   font-size:clamp(1.5rem, 3vw, 2rem);
   font-weight:800;

--- a/catalogue/index.html
+++ b/catalogue/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HOTWAV × AJT PRO — Catalogue 2026</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.31.0/dist/tabler-icons.min.css">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -22,15 +23,15 @@
       <span class="sep">×</span>
       <img src="imgs/ajt-logo.png" alt="AJT PRO" onerror="this.style.display='none'">
     </a>
-    <button class="nav-menu-btn" onclick="document.querySelector('.nav-tabs').classList.toggle('open')">☰</button>
+    <button class="nav-menu-btn" onclick="document.querySelector('.nav-tabs').classList.toggle('open')"><i class="ti ti-menu-2"></i></button>
     <div class="nav-tabs">
       <button class="nav-tab active"  onclick="filterCategory('all', this)">Tout</button>
-      <button class="nav-tab" onclick="filterCategory('rugged-phones', this)">🛡️ Smartphones Renforcés</button>
-      <button class="nav-tab" onclick="filterCategory('phones', this)">📱 Smartphones</button>
-      <button class="nav-tab" onclick="filterCategory('rugged-tabs', this)">🛡️ Tablettes Renforcées</button>
-      <button class="nav-tab" onclick="filterCategory('tabs', this)">📲 Tablettes</button>
+      <button class="nav-tab" onclick="filterCategory('rugged-phones', this)"><i class="ti ti-shield-check"></i> Smartphones Renforcés</button>
+      <button class="nav-tab" onclick="filterCategory('phones', this)"><i class="ti ti-device-mobile"></i> Smartphones</button>
+      <button class="nav-tab" onclick="filterCategory('rugged-tabs', this)"><i class="ti ti-shield-check"></i> Tablettes Renforcées</button>
+      <button class="nav-tab" onclick="filterCategory('tabs', this)"><i class="ti ti-device-tablet"></i> Tablettes</button>
     </div>
-    <a href="https://shop.ajtpro.com" class="nav-shop" target="_blank">🛒 Boutique</a>
+    <a href="https://shop.ajtpro.com" class="nav-shop" target="_blank"><i class="ti ti-shopping-cart"></i> Boutique</a>
   </div>
 </nav>
 
@@ -50,7 +51,7 @@
 <!-- Section 1 : Smartphones Renforcés -->
 <div class="section reveal" data-cat="rugged-phones">
   <div class="section-header">
-    <span class="section-icon">🛡️</span>
+    <i class="ti ti-shield-check section-icon"></i>
     <h2 class="section-title">Smartphones Renforcés</h2>
   </div>
   <p class="section-sub">IP68 · IP69K · MIL-STD 810</p>
@@ -60,7 +61,7 @@
 <!-- Section 2 : Smartphones -->
 <div class="section reveal" data-cat="phones">
   <div class="section-header">
-    <span class="section-icon">📱</span>
+    <i class="ti ti-device-mobile section-icon"></i>
     <h2 class="section-title">Smartphones</h2>
   </div>
   <p class="section-sub">Performance & Design</p>
@@ -70,7 +71,7 @@
 <!-- Section 3 : Tablettes Renforcées -->
 <div class="section reveal" data-cat="rugged-tabs">
   <div class="section-header">
-    <span class="section-icon">🛡️</span>
+    <i class="ti ti-shield-check section-icon"></i>
     <h2 class="section-title">Tablettes Renforcées</h2>
   </div>
   <p class="section-sub">IP68 · IP69K · MIL-STD 810</p>
@@ -80,7 +81,7 @@
 <!-- Section 4 : Tablettes -->
 <div class="section reveal" data-cat="tabs">
   <div class="section-header">
-    <span class="section-icon">📲</span>
+    <i class="ti ti-device-tablet section-icon"></i>
     <h2 class="section-title">Tablettes</h2>
   </div>
   <p class="section-sub">Productivité & Divertissement</p>
@@ -90,7 +91,7 @@
 <!-- Modal produit -->
 <div class="modal-overlay" id="modal" onclick="if(event.target===this) closeModal()">
   <div class="modal">
-    <button class="modal-close" onclick="closeModal()">✕</button>
+    <button class="modal-close" onclick="closeModal()"><i class="ti ti-x"></i></button>
     <div class="modal-content">
       <div class="modal-img-side">
         <img id="modal-img" src="" alt=""
@@ -105,7 +106,7 @@
           <div class="modal-color-dots" id="modal-colors"></div>
           <div class="modal-color-name" id="modal-color-name"></div>
         </div>
-        <a class="modal-cart" id="modal-cart" href="#" target="_blank">🛒 Voir sur la boutique</a>
+        <a class="modal-cart" id="modal-cart" href="#" target="_blank"><i class="ti ti-shopping-cart"></i> Voir sur la boutique</a>
       </div>
     </div>
   </div>
@@ -122,7 +123,7 @@
     </a>
   </div>
   <p>Catalogue HOTWAV 2026 — Distribué en France par AJT Pro</p>
-  <a href="https://shop.ajtpro.com" class="footer-link" target="_blank">🛒 Visiter la boutique en ligne →</a>
+  <a href="https://shop.ajtpro.com" class="footer-link" target="_blank"><i class="ti ti-shopping-cart"></i> Visiter la boutique en ligne</a>
 </footer>
 
 <script src="js/products.js"></script>

--- a/catalogue/js/app.js
+++ b/catalogue/js/app.js
@@ -48,7 +48,7 @@ function renderProducts() {
              href="${p.badge === 'soon' ? '#' : BASE + c0.url}"
              target="_blank"
              onclick="event.stopPropagation()">
-            ${p.badge === 'soon' ? '⏳' : '🛒'}
+            <i class="ti ${p.badge === 'soon' ? 'ti-clock-hour3' : 'ti-shopping-cart'}"></i>
           </a>
         </div>
       </div>
@@ -132,11 +132,11 @@ function openModal(idx) {
 
   const cart = document.getElementById('modal-cart');
   if (p.badge === 'soon') {
-    cart.textContent   = '⏳ Bientôt disponible';
+    cart.innerHTML     = '<i class="ti ti-clock-hour3"></i> Bientôt disponible';
     cart.href          = '#';
     cart.style.opacity = '.5';
   } else {
-    cart.textContent   = '🛒 Voir sur la boutique';
+    cart.innerHTML     = '<i class="ti ti-shopping-cart"></i> Voir sur la boutique';
     cart.href          = BASE + p.colors[0].url;
     cart.style.opacity = '1';
   }
@@ -153,7 +153,11 @@ function switchModalColor(ci) {
   modalImg.style.display = '';
   modalImg.src = c.img;
   document.getElementById('modal-color-name').textContent = c.name;
-  if (p.badge !== 'soon') document.getElementById('modal-cart').href = BASE + c.url;
+  if (p.badge !== 'soon') {
+    const cart = document.getElementById('modal-cart');
+    cart.innerHTML = '<i class="ti ti-shopping-cart"></i> Voir sur la boutique';
+    cart.href = BASE + c.url;
+  }
 
   document.querySelectorAll('.modal-color-dot').forEach((d, i) => {
     d.classList.toggle('active', i === ci);


### PR DESCRIPTION
## Summary
- Intègre Tabler Icons via CDN (@tabler/icons-webfont@3.31.0)
- Remplace tous les emojis (🛡️📱📲🛒⏳☰✕) par des icônes SVG vectorielles cohérentes
- Navbar, sections, modal et footer uniformisés avec les mêmes icônes
- Icônes redimensionnées proprement (15px nav, 28px sections)

## Test plan
- [ ] Navbar : icônes shield-check, device-mobile, device-tablet visibles
- [ ] Bouton menu mobile : ti-menu-2
- [ ] Bouton boutique : ti-shopping-cart
- [ ] Sections : icônes shield-check / device-mobile / device-tablet
- [ ] Modal : bouton fermer ti-x, bouton panier ti-shopping-cart
- [ ] Cards "bientôt" : ti-clock-hour3
- [ ] Footer : ti-shopping-cart

🤖 Generated with [Claude Code](https://claude.com/claude-code)