### PR TITLE
feat(matching): add Rapport tab with charts and run history

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -361,6 +361,7 @@ Automatisation complete du cycle nocturne : sync Odoo + fournisseurs + re-matchi
   - Seuls les produits non encore resolus sont re-evalues (reduction de ~95% du scoring)
   - **Option A** : re-evaluation automatique des pending/rejected quand de nouveaux labels arrivent pour la meme brand
   - **Option D** : full rescore chaque dimanche — reset des auto-matches et pending, re-evaluation complete du catalogue
+  - **Onglet Rapport** : graphiques d'evolution (cout LLM, taux de cache, repartition resultats, produits traites) + tableau historique des runs
 - **Planificateur** (`utils/nightly_scheduler.py`) : `threading.Timer` verifiant chaque minute si l'heure UTC configuree est atteinte. Variable `_last_run_date` pour eviter de relancer plusieurs fois la meme nuit
 - **Rapport email** : webhook n8n (stdlib `urllib`, zero dependance externe). Payload JSON avec statut, compteurs, duree, lien de validation et corps HTML. Workflow n8n importable dans `n8n_nightly_workflow.json`
 - **8 endpoints REST** (`routes/nightly.py`, prefix `/nightly`) : GET/PUT config, POST trigger, GET jobs, GET jobs/<id>, GET/POST/DELETE recipients

--- a/backend/alembic/versions/t1_matching_run_extra_counters.py
+++ b/backend/alembic/versions/t1_matching_run_extra_counters.py
@@ -1,0 +1,26 @@
+"""Add cache hit counters to matching_runs
+
+Revision ID: t1_matching_run_extra_counters
+Revises: s1_label_cache_last_seen_run
+Create Date: 2026-02-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "t1_matching_run_extra_counters"
+down_revision = "s1_label_cache_last_seen_run"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("matching_runs", sa.Column("cross_supplier_hits", sa.Integer(), nullable=True))
+    op.add_column("matching_runs", sa.Column("fuzzy_hits", sa.Integer(), nullable=True))
+    op.add_column("matching_runs", sa.Column("attr_share_hits", sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("matching_runs", "attr_share_hits")
+    op.drop_column("matching_runs", "fuzzy_hits")
+    op.drop_column("matching_runs", "cross_supplier_hits")

--- a/backend/models.py
+++ b/backend/models.py
@@ -583,6 +583,9 @@ class MatchingRun(db.Model):
     cost_estimate = db.Column(db.Float, nullable=True)
     duration_seconds = db.Column(db.Float, nullable=True)
     error_message = db.Column(db.Text, nullable=True)
+    cross_supplier_hits = db.Column(db.Integer, nullable=True)
+    fuzzy_hits = db.Column(db.Integer, nullable=True)
+    attr_share_hits = db.Column(db.Integer, nullable=True)
 
 
 class NightlyEmailRecipient(db.Model):

--- a/backend/routes/matching.py
+++ b/backend/routes/matching.py
@@ -557,6 +557,44 @@ def matching_stats():
     }), 200
 
 
+@bp.route("/matching/runs", methods=["GET"])
+@token_required("admin")
+def list_runs():
+    """Return the most recent matching runs for the Rapport tab."""
+    limit = request.args.get("limit", 30, type=int)
+    limit = min(limit, 100)
+
+    runs = (
+        MatchingRun.query
+        .order_by(MatchingRun.id.desc())
+        .limit(limit)
+        .all()
+    )
+
+    return jsonify([
+        {
+            "id": r.id,
+            "ran_at": r.ran_at.isoformat() if r.ran_at else None,
+            "status": r.status,
+            "total_products": r.total_products,
+            "from_cache": r.from_cache,
+            "llm_calls": r.llm_calls,
+            "auto_matched": r.auto_matched,
+            "pending_review": r.pending_review,
+            "auto_rejected": r.auto_rejected,
+            "not_found": r.not_found,
+            "errors": r.errors,
+            "cost_estimate": r.cost_estimate,
+            "duration_seconds": r.duration_seconds,
+            "cross_supplier_hits": r.cross_supplier_hits,
+            "fuzzy_hits": r.fuzzy_hits,
+            "attr_share_hits": r.attr_share_hits,
+            "nightly_job_id": r.nightly_job_id,
+        }
+        for r in runs
+    ]), 200
+
+
 @bp.route("/matching/cache", methods=["GET"])
 @token_required("admin")
 def list_cache():

--- a/backend/utils/llm_matching.py
+++ b/backend/utils/llm_matching.py
@@ -1066,6 +1066,9 @@ def run_matching_job(
             mr.cost_estimate = cost_estimate
             mr.duration_seconds = duration
             mr.error_message = error_message
+            mr.cross_supplier_hits = cross_supplier_hits
+            mr.fuzzy_hits = fuzzy_hits
+            mr.attr_share_hits = attr_share_hits
             db.session.commit()
     except Exception:
         current_app.logger.exception("Failed to update MatchingRun #%d", run_id)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -899,6 +899,32 @@ export interface CacheList {
   per_page: number;
 }
 
+export interface MatchingRunItem {
+  id: number;
+  ran_at: string | null;
+  status: string;
+  total_products: number | null;
+  from_cache: number | null;
+  llm_calls: number | null;
+  auto_matched: number | null;
+  pending_review: number | null;
+  auto_rejected: number | null;
+  not_found: number | null;
+  errors: number | null;
+  cost_estimate: number | null;
+  duration_seconds: number | null;
+  cross_supplier_hits: number | null;
+  fuzzy_hits: number | null;
+  attr_share_hits: number | null;
+  nightly_job_id: number | null;
+}
+
+export async function fetchMatchingRuns(limit = 30): Promise<MatchingRunItem[]> {
+  const res = await fetchWithAuth(`${API_BASE}/matching/runs?limit=${limit}`);
+  if (!res.ok) throw new Error(await extractErrorMessage(res));
+  return res.json();
+}
+
 export async function runMatching(supplierId?: number, limit?: number): Promise<void> {
   const body: Record<string, unknown> = {};
   if (supplierId) body.supplier_id = supplierId;


### PR DESCRIPTION
## Summary

- **Rapport tab**: new tab on the Matching page with 3 SVG charts (cost/cache, stacked results, products processed) and a detailed run history table
- **MatchingRun extra counters**: persist `cross_supplier_hits`, `fuzzy_hits`, `attr_share_hits` in the database
- **New endpoint**: `GET /matching/runs` returns last 30 runs with all metrics
- **Migration**: `t1_matching_run_extra_counters` adds 3 columns to `matching_runs`

## Test plan

- [x] 321 backend tests pass (pytest)
- [x] Frontend builds successfully (vite)
- [ ] Navigate to `/matching` → Rapport tab → verify charts render with historical data
- [ ] Run a matching job → refresh → verify new run appears in charts and table
- [ ] Verify migration applies cleanly on prod (`make alembic-upgrade`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)