### PR TITLE
fix(matching): make migrations idempotent for prod

### DIFF
--- a/backend/alembic/versions/r1_product_ean_history.py
+++ b/backend/alembic/versions/r1_product_ean_history.py
@@ -15,21 +15,24 @@ depends_on = None
 
 
 def upgrade():
-    op.create_table(
-        "product_ean_history",
-        sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("product_id", sa.Integer(), sa.ForeignKey("products.id"), nullable=False),
-        sa.Column("ean", sa.String(20), nullable=False),
-        sa.Column("supplier_id", sa.Integer(), sa.ForeignKey("suppliers.id"), nullable=False),
-        sa.Column("matching_run_id", sa.Integer(), sa.ForeignKey("matching_runs.id"), nullable=True),
-        sa.Column("source", sa.String(20), nullable=False),
-        sa.Column("seen_at", sa.DateTime(), server_default=sa.func.now()),
-    )
-    op.create_index(
-        "ix_product_ean_history_product_ean",
-        "product_ean_history",
-        ["product_id", "ean"],
-    )
+    conn = op.get_bind()
+    # Table may already exist if created by db.create_all()
+    if not conn.dialect.has_table(conn, "product_ean_history"):
+        op.create_table(
+            "product_ean_history",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("product_id", sa.Integer(), sa.ForeignKey("products.id"), nullable=False),
+            sa.Column("ean", sa.String(20), nullable=False),
+            sa.Column("supplier_id", sa.Integer(), sa.ForeignKey("suppliers.id"), nullable=False),
+            sa.Column("matching_run_id", sa.Integer(), sa.ForeignKey("matching_runs.id"), nullable=True),
+            sa.Column("source", sa.String(20), nullable=False),
+            sa.Column("seen_at", sa.DateTime(), server_default=sa.func.now()),
+        )
+    # Index may also already exist
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_product_ean_history_product_ean
+        ON product_ean_history (product_id, ean)
+    """)
 
 
 def downgrade():

--- a/backend/alembic/versions/s1_label_cache_last_seen_run.py
+++ b/backend/alembic/versions/s1_label_cache_last_seen_run.py
@@ -15,11 +15,17 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        "label_cache",
-        sa.Column("last_seen_run_id", sa.Integer(), sa.ForeignKey("matching_runs.id"), nullable=True),
-    )
-    op.create_index("ix_label_cache_last_seen_run", "label_cache", ["last_seen_run_id"])
+    conn = op.get_bind()
+    columns = [c["name"] for c in sa.inspect(conn).get_columns("label_cache")]
+    if "last_seen_run_id" not in columns:
+        op.add_column(
+            "label_cache",
+            sa.Column("last_seen_run_id", sa.Integer(), sa.ForeignKey("matching_runs.id"), nullable=True),
+        )
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_label_cache_last_seen_run
+        ON label_cache (last_seen_run_id)
+    """)
 
 
 def downgrade():

--- a/backend/alembic/versions/t1_matching_run_extra_counters.py
+++ b/backend/alembic/versions/t1_matching_run_extra_counters.py
@@ -15,9 +15,14 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("matching_runs", sa.Column("cross_supplier_hits", sa.Integer(), nullable=True))
-    op.add_column("matching_runs", sa.Column("fuzzy_hits", sa.Integer(), nullable=True))
-    op.add_column("matching_runs", sa.Column("attr_share_hits", sa.Integer(), nullable=True))
+    conn = op.get_bind()
+    columns = [c["name"] for c in sa.inspect(conn).get_columns("matching_runs")]
+    if "cross_supplier_hits" not in columns:
+        op.add_column("matching_runs", sa.Column("cross_supplier_hits", sa.Integer(), nullable=True))
+    if "fuzzy_hits" not in columns:
+        op.add_column("matching_runs", sa.Column("fuzzy_hits", sa.Integer(), nullable=True))
+    if "attr_share_hits" not in columns:
+        op.add_column("matching_runs", sa.Column("attr_share_hits", sa.Integer(), nullable=True))
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- Migrations r1 (product_ean_history), s1 (label_cache last_seen_run_id) and t1 (matching_run counters) failed on prod because `db.create_all()` had already created the schema
- Made all 3 migrations idempotent: check if table/column exists before creating
- Fixes 500 error on `/matching/runs` and `/matching/stats` endpoints in production

## Test plan
- [x] 321 backend tests pass
- [x] `make alembic-upgrade` succeeds locally (idempotent)
- [ ] Deploy to prod → verify `alembic upgrade head` passes
- [ ] Verify `/matching` → Rapport tab loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)