### PR TITLE
fix(matching): remove db.create_all() from app startup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -64,7 +64,9 @@ def create_app():
     configure_logging(app)
 
     with app.app_context():
-        db.create_all()
+        # Schema is managed by Alembic migrations (alembic upgrade head).
+        # Do NOT call db.create_all() here — it bypasses Alembic and causes
+        # DuplicateTable errors when migrations run later.
         _cleanup_orphaned_jobs()
 
     register_routes(app)


### PR DESCRIPTION
## Summary
- Removed `db.create_all()` from `app.py` startup — root cause of migration failures in production
- Schema is now managed exclusively by Alembic (`alembic upgrade head` in `deploy-ci.sh`)
- Prevents future `DuplicateTable` / `DuplicateColumn` errors when deploying new migrations

## Context
Every app restart called `db.create_all()`, creating tables/columns directly in PostgreSQL. When Alembic then tried to run its migrations, it found the objects already existed and crashed. This is what caused the 500 error on `/matching/runs` after PR #281.

## Test plan
- [x] 321 backend tests pass
- [x] Backend restarts cleanly without `db.create_all()`
- [x] `make alembic-upgrade` still works (idempotent migrations from PR #282)

🤖 Generated with [Claude Code](https://claude.com/claude-code)