### PR TITLE
fix(catalogue): nginx /catalogue/admin route fix (Content-Type text/html)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,7 +28,9 @@ server {
 
     # Catalogue statique (page publique indépendante de React)
     location = /catalogue/admin {
-        rewrite ^ /catalogue/admin.html break;
+        root /usr/share/nginx/html;
+        default_type text/html;
+        try_files /catalogue/admin.html =404;
     }
     location /catalogue {
         alias /usr/share/nginx/html/catalogue;


### PR DESCRIPTION
## Summary
- Replace `rewrite break` with `try_files + default_type text/html` for the `/catalogue/admin` nginx route
- `rewrite break` was causing the browser to show a file save dialog (Content-Type undetermined → `application/octet-stream`)
- Also includes the catalogue backoffice itself (CRUD, palette couleurs, import/export)

## Test plan
- [ ] `https://ajtpro.tulip-saas.fr/catalogue/admin` ouvre l'interface admin (pas de save dialog)
- [ ] `https://ajtpro.tulip-saas.fr/catalogue/` fonctionne toujours (vitrine intacte)
- [ ] `https://ajtpro.tulip-saas.fr/catalogue/admin.html` fonctionne aussi

🤖 Generated with [Claude Code](https://claude.com/claude-code)