### PR TITLE
fix(odoo): extract memory from description and shorten migration IDs

### DIFF
--- a/backend/alembic/versions/v1_norm_desc_units.py
+++ b/backend/alembic/versions/v1_norm_desc_units.py
@@ -1,6 +1,6 @@
 """Normalize storage units in product descriptions (GB -> Go, TB -> To).
 
-Revision ID: v1_normalize_description_units
+Revision ID: v1_norm_desc_units
 Revises: u1_matching_run_coverage
 Create Date: 2026-02-27
 """
@@ -10,7 +10,7 @@ import re
 from alembic import op
 import sqlalchemy as sa
 
-revision = "v1_normalize_description_units"
+revision = "v1_norm_desc_units"
 down_revision = "u1_matching_run_coverage"
 branch_labels = None
 depends_on = None
@@ -26,6 +26,9 @@ def _normalize(text):
 
 
 def upgrade():
+    # Widen alembic_version column if needed (default 32 is too short)
+    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE varchar(128)")
+
     conn = op.get_bind()
     rows = conn.execute(
         sa.text("SELECT id, description FROM products WHERE description ~* '[0-9]+\\s*(GB|TB)'")

--- a/backend/alembic/versions/v2_populate_ram.py
+++ b/backend/alembic/versions/v2_populate_ram.py
@@ -1,15 +1,15 @@
 """Populate RAM_id from description pattern (e.g. 8/256Go -> RAM=8 Go).
 
-Revision ID: v2_populate_ram_from_description
-Revises: v1_normalize_description_units
+Revision ID: v2_populate_ram
+Revises: v1_norm_desc_units
 Create Date: 2026-02-27
 """
 
 from alembic import op
 import sqlalchemy as sa
 
-revision = "v2_populate_ram_from_description"
-down_revision = "v1_normalize_description_units"
+revision = "v2_populate_ram"
+down_revision = "v1_norm_desc_units"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/v3_populate_memory.py
+++ b/backend/alembic/versions/v3_populate_memory.py
@@ -1,0 +1,62 @@
+"""Populate memory_id from description pattern (e.g. 8/256Go -> Memory=256 Go).
+
+Revision ID: v3_populate_memory
+Revises: v2_populate_ram
+Create Date: 2026-02-27
+"""
+
+import re
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "v3_populate_memory"
+down_revision = "v2_populate_ram"
+branch_labels = None
+depends_on = None
+
+# Matches "X/YGo" (RAM/Storage) or standalone "YGo" (Storage only)
+_RAM_STORAGE_RE = re.compile(r"\d+/(\d+)\s*Go", re.IGNORECASE)
+_STORAGE_RE = re.compile(r"(\d+)\s*Go", re.IGNORECASE)
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Build memory_options lookup: "128" -> id, "256" -> id, etc.
+    mem_rows = conn.execute(sa.text("SELECT id, memory FROM memory_options")).fetchall()
+    mem_lookup = {}
+    for row in mem_rows:
+        num = row[1].replace(" Go", "").replace(" To", "").strip()
+        mem_lookup[num] = row[0]
+
+    # Find products with no memory_id and a storage pattern in description
+    products = conn.execute(
+        sa.text(
+            "SELECT id, description FROM products "
+            "WHERE memory_id IS NULL AND description ~* '[0-9]+\\s*Go'"
+        )
+    ).fetchall()
+
+    count = 0
+    for row in products:
+        desc = row[1]
+        # Try RAM/Storage pattern first, then standalone Storage
+        m = _RAM_STORAGE_RE.search(desc)
+        if not m:
+            m = _STORAGE_RE.search(desc)
+        if m:
+            storage_val = m.group(1)
+            if storage_val in mem_lookup:
+                conn.execute(
+                    sa.text("UPDATE products SET memory_id = :mem_id WHERE id = :id"),
+                    {"mem_id": mem_lookup[storage_val], "id": row[0]},
+                )
+                count += 1
+
+    if count:
+        print(f"  -> Populated memory_id for {count} products")
+
+
+def downgrade():
+    pass

--- a/backend/utils/odoo_sync.py
+++ b/backend/utils/odoo_sync.py
@@ -266,7 +266,19 @@ def _parse_name_fallback(
             found = _find_in(color_lookup)
         result["color_id"] = found
     if memory_id is None:
-        result["memory_id"] = _find_in(memory_lookup)
+        # Try to extract storage from "RAM/StorageGo" or "StorageGo" pattern
+        mem_match = re.search(r"\b\d+/(\d+)\s*(?:go|gb)\b", name_lower)
+        if not mem_match:
+            mem_match = re.search(r"\b(\d+)\s*(?:go|gb)\b", name_lower)
+        if mem_match:
+            mem_key = f"{mem_match.group(1)} go"
+            if mem_key in memory_lookup:
+                matched_strings.append(mem_key)
+                result["memory_id"] = memory_lookup[mem_key]
+            else:
+                result["memory_id"] = _find_in(memory_lookup)
+        else:
+            result["memory_id"] = _find_in(memory_lookup)
     if ram_id is None:
         # Try to extract RAM from "RAM/StorageGo" pattern (e.g. "8/256Go", "8/256GB")
         ram_match = re.search(r"\b(\d+)/\d+\s*(?:go|gb)\b", name_lower)


### PR DESCRIPTION
Parse storage from X/YGo and standalone XGo patterns during Odoo sync to populate memory_id. Migration backfills 1040 existing products. Shorten migration revision IDs to fit alembic_version varchar(32).