### PR TITLE
fix(deploy): correct legacy alembic stamp before running migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ backend/instance/*
 backend/alembic/versions/__pycache__/
 backend/alembic/versions/*.pyc
 
+docs/API_fournisseurs
+
 **/__pycache__
 **/*.pyc
 

--- a/deploy-ci.sh
+++ b/deploy-ci.sh
@@ -72,6 +72,11 @@ docker network rm ajtpro_default 2>/dev/null || true
 log "Demarrage des containers..."
 docker compose -f "$COMPOSE_FILE" up -d
 
+# 7b. Fix alembic stamp if legacy revision name exists (one-time fix)
+docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U postgres -d ajtpro -c \
+  "UPDATE alembic_version SET version_num = 'v2_populate_ram' WHERE version_num = 'v2_populate_ram_from_description';" 2>/dev/null \
+  && log "Alembic stamp corrige (legacy rename)" || true
+
 # 8. Attente que le backend soit pret + migrations Alembic
 log "Attente que le backend demarre..."
 for i in $(seq 1 30); do


### PR DESCRIPTION
Add one-time SQL fix in deploy-ci.sh to update the alembic_version stamp from 'v2_populate_ram_from_description' to 'v2_populate_ram' (renamed in 31b4ef8). Also ignore docs/API_fournisseurs directory.