### PR TITLE
fix(deploy): load .env variables in deploy-ci.sh for postgres credent…

### DIFF
--- a/deploy-ci.sh
+++ b/deploy-ci.sh
@@ -19,6 +19,15 @@ fail() { echo -e "${RED}[$(date '+%H:%M:%S')] FATAL: $1${NC}"; exit 1; }
 
 cd "$APP_DIR" || fail "Repertoire $APP_DIR introuvable"
 
+# Load environment variables from .env
+if [ -f ".env" ]; then
+    set -a
+    source .env
+    set +a
+else
+    warn ".env file not found, using environment defaults"
+fi
+
 # 1. Backup DB
 log "Backup de la base de donnees..."
 if [ -f "./save_db.sh" ]; then


### PR DESCRIPTION
…ials

The deployment script was failing because POSTGRES_USER and POSTGRES_DB variables were not loaded from .env, causing alembic stamp migration to fail.

Add proper .env sourcing at script startup to make credentials available.