### PR TITLE
fix(matching): region inference + deploy fix

### DIFF
--- a/deploy-ci.sh
+++ b/deploy-ci.sh
@@ -95,7 +95,9 @@ log "Demarrage des containers..."
 docker compose -f "$COMPOSE_FILE" up -d
 
 # 7b. Fix alembic stamp if legacy revision name exists (one-time fix)
-docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -c \
+PG_USER="$(grep -m1 '^POSTGRES_USER=' "$APP_DIR/.env" | cut -d= -f2)"
+PG_DB="$(grep -m1 '^POSTGRES_DB=' "$APP_DIR/.env" | cut -d= -f2)"
+docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U "${PG_USER}" -d "${PG_DB}" -c \
   "UPDATE alembic_version SET version_num = 'v2_populate_ram' WHERE version_num = 'v2_populate_ram_from_description';" 2>/dev/null \
   && log "Alembic stamp corrige (legacy rename)" || true
 


### PR DESCRIPTION
## Summary

- **Fix cross-region matching bug**: Products with region-specific text in model (e.g. "Indian Spec") but NULL region were incorrectly treated as EU, allowing invalid cross-region matches. Added `_infer_region_from_text()` to detect region patterns and Alembic migration to backfill 40 products (29 IN + 11 US).
- **Fix deploy-ci.sh**: Read PG credentials directly from `.env` file via grep instead of relying on shell variables, fixing `POSTGRES_USER: unbound variable` error.
- **Matching search improvement**: Replace model-only filter with multi-attribute search (brand, model, storage, color, region).
- **Auth**: Grant user role access to matching page.
- **Catalogue**: Image upload with edit overlay and production deployment.

## Test plan

- [x] All 354 backend tests passing
- [x] Frontend tests passing
- [x] Region inference tested for all patterns (IN, US, DE, JP, AU, CA, BR, MX)
- [x] Product 5211 correctly inferred as region=IN
- [ ] Deploy pipeline succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)