### PR TITLE
fix(matching): handle parenthesized region patterns (US Spec)

### DIFF
--- a/backend/utils/llm_matching.py
+++ b/backend/utils/llm_matching.py
@@ -438,7 +438,9 @@ def score_match(
     # so that storage embedded in model names doesn't penalize the fuzzy ratio
     prod_model = re.sub(r'\b\d+\s*(?:go|gb|to|tb)\b', '', prod_model, flags=re.IGNORECASE).strip()
     # Strip region suffixes (e.g. "iPhone 15 Indian Spec" → "iPhone 15") to avoid fuzzy match penalty
-    prod_model = re.sub(r'\b(?:indian|us|de|jp|au|ca|br|mx)(?:\s+spec)?\b', '', prod_model, flags=re.IGNORECASE).strip()
+    # Also handles parenthesized forms like "(US Spec)"
+    prod_model = re.sub(r'\(?\b(?:indian|us|de|jp|au|ca|br|mx)(?:\s+spec)?\b\)?', '', prod_model, flags=re.IGNORECASE).strip()
+    prod_model = re.sub(r'\(\s*\)', '', prod_model)  # Remove empty parentheses left over
     prod_model = re.sub(r'\s+', ' ', prod_model).strip()  # Collapse multiple spaces
 
     if ext_model and prod_model:


### PR DESCRIPTION
## Summary
- Handle `(US Spec)` parenthesized region patterns in product model names
- Clean up empty parentheses `()` left over after stripping
- Fixes US Spec products (iPhone SE3, AirPods) that scored too low on model_family

## Impact
28 non-EU products should now auto-match or score higher in pending review.

Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)