### PR TITLE
fix(pipeline): remove lint step from deploy (not in ci.yml either)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,6 @@ jobs:
         run: npm ci
         working-directory: frontend
 
-      - name: Lint frontend
-        run: npx eslint src/
-        working-directory: frontend
-
       - name: Test frontend
         run: npx vitest run --reporter=verbose
         working-directory: frontend


### PR DESCRIPTION
The eslint flat config requires typescript-eslint which isn't available in the CI runner. Align deploy test gate with ci.yml: tests only.