### PR TITLE
fix(catalogue): add cache-busting for re-uploaded images

### DIFF
--- a/catalogue/upload-server.py
+++ b/catalogue/upload-server.py
@@ -12,6 +12,7 @@ Options (variables d'environnement):
 
 import os
 import re
+import time
 import unicodedata
 from pathlib import Path
 
@@ -96,7 +97,8 @@ def upload():
     IMGS_DIR.mkdir(exist_ok=True)
     img.save(IMGS_DIR / filename, "PNG", optimize=True)
 
-    return jsonify({"path": f"imgs/{filename}"}), 200
+    cache_bust = int(time.time())
+    return jsonify({"path": f"imgs/{filename}?v={cache_bust}"}), 200
 
 
 if __name__ == "__main__":

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,6 +19,13 @@ server {
         access_log off;
     }
 
+    # Images catalogue — cache court (re-uploadables)
+    location /catalogue/imgs/ {
+        alias /usr/share/nginx/html/catalogue/imgs/;
+        expires 1h;
+        add_header Cache-Control "public, must-revalidate";
+    }
+
     # Gestion des assets (js, css, images, etc.)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
Upload server now appends ?v=timestamp to returned image paths so browsers fetch the new version. Catalogue images also get a shorter nginx cache (1h, must-revalidate) instead of 1y immutable.