### PR TITLE
fix(matching): increase BM25/FAISS top_k from 50/100 to 200/200

### DIFF
--- a/backend/scripts/benchmark_matching_v2.py
+++ b/backend/scripts/benchmark_matching_v2.py
@@ -179,12 +179,12 @@ def main():
 
             # --- V2: BM25 + FAISS ---
             t0 = time.time()
-            bm25_results = bm25_blocker.get_candidates(product, top_k=50)
+            bm25_results = bm25_blocker.get_candidates(product, top_k=200)
             bm25_ids = {e.id for e in bm25_results}
 
             faiss_ids = set()
             if faiss_index and product.id in product_embeddings:
-                faiss_results = faiss_index.search(product_embeddings[product.id], top_k=100)
+                faiss_results = faiss_index.search(product_embeddings[product.id], top_k=200)
                 faiss_ids = {lid for lid, _ in faiss_results}
 
             v2_candidate_ids = bm25_ids | faiss_ids

--- a/backend/utils/matching/retrieval_pipeline.py
+++ b/backend/utils/matching/retrieval_pipeline.py
@@ -43,8 +43,8 @@ class RetrievalPipeline:
         ean_to_product_ids: Dict,
         threshold_auto: int = 90,
         threshold_review: int = 70,
-        bm25_top_k: int = 50,
-        faiss_top_k: int = 100,
+        bm25_top_k: int = 200,
+        faiss_top_k: int = 200,
     ) -> None:
         self._cache_entries = cache_entries
         self._score_match = score_match_fn


### PR DESCRIPTION
First benchmark showed 53 regressions (5.8%) — all candidates missed by the too-aggressive blocking. Wider recall window trades some speed for correctness parity with V1.